### PR TITLE
docs: fix stale LICENSE link and reconcile GOVERNANCE CLA wording

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -84,11 +84,13 @@ changelog.
 ## Licensing
 
 All contributions are accepted under the project's
-[Apache License 2.0](./LICENSE). By submitting a PR you agree your
+[Apache License 2.0](./LICENSE.txt). By submitting a PR you agree your
 contribution is licensed under Apache-2.0.
 
-There is no Contributor License Agreement (CLA). The Apache-2.0 license
-includes an implicit patent grant that covers the common case.
+Contributions also require signing the [Salesforce
+CLA](https://cla.salesforce.com/sign-cla) (one-time, covers all
+Salesforce open-source projects). See [CONTRIBUTING.md](./CONTRIBUTING.md)
+for details.
 
 ## Changing this document
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/salesforce/sf-pi/actions/workflows/ci.yml/badge.svg)](https://github.com/salesforce/sf-pi/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/salesforce/sf-pi/actions/workflows/codeql.yml/badge.svg)](https://github.com/salesforce/sf-pi/actions/workflows/codeql.yml)
 [![Coverage](https://codecov.io/gh/salesforce/sf-pi/branch/main/graph/badge.svg)](https://codecov.io/gh/salesforce/sf-pi)
-[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE.txt)
 [![Node](https://img.shields.io/badge/node-%3E%3D20-brightgreen.svg)](https://nodejs.org/)
 [![Last commit](https://img.shields.io/github/last-commit/salesforce/sf-pi)](https://github.com/salesforce/sf-pi/commits/main)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
@@ -409,4 +409,4 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md). Please also read our
 
 ## License
 
-Licensed under the [Apache License 2.0](./LICENSE).
+Licensed under the [Apache License 2.0](./LICENSE.txt).


### PR DESCRIPTION
Pre-flight cleanup before flipping the repo to public.

## Issues found

1. **Stale `./LICENSE` link**: README.md (badge + License section) and GOVERNANCE.md still linked to `./LICENSE`, but OSPO requires `LICENSE.txt`. We renamed the file during the initial public release but missed the inline links.
2. **Contradictory CLA wording**: GOVERNANCE.md said 'There is no Contributor License Agreement (CLA)'. That was true on the private repo but not on `salesforce/sf-pi` — CONTRIBUTING.md (adopted from the OSPO template) now requires signing the Salesforce CLA. Reconciling GOVERNANCE with the new policy.

## Why this matters

The License badge on the README would 404 once the repo flips to public; and the CLA wording mismatch could lead to confused contributors.

## Scope

- README.md: 2 link fixes (badge + bottom License section)
- GOVERNANCE.md: 1 link fix + rewrite the 'Licensing' section's second paragraph to reference the Salesforce CLA

No other files touched.