### PR TITLE
ci(ruleset): promote 6 new checks to required status

### DIFF
--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -11,17 +11,15 @@
 #      `uses:` line points at a mutable ref (branch or version tag).
 name: Workflow lint
 
+# Runs on every push/PR (no paths: filter) so the ruleset can treat both
+# jobs as required status checks. If we filtered by path, PRs that don't
+# touch workflows would never report a status and would be blocked from
+# merging indefinitely. The jobs are ~5–10s each, so the cost is trivial.
 on:
   push:
     branches: [main]
-    paths:
-      - ".github/workflows/**"
-      - ".github/actions/**"
   pull_request:
     branches: [main]
-    paths:
-      - ".github/workflows/**"
-      - ".github/actions/**"
   workflow_dispatch:
 
 permissions:

--- a/scripts/apply-main-ruleset.sh
+++ b/scripts/apply-main-ruleset.sh
@@ -17,9 +17,16 @@
 #   - Require PR before merging, 1 approving review, CODEOWNERS review,
 #     squash-only merge method
 #   - Required status checks (strict=false so rebases aren't forced):
-#       Validate, npm audit (production), gitleaks
-#     CodeQL is NOT required here because its workflow is schedule-only
-#     (weekly) plus workflow_dispatch — requiring it would stall every PR.
+#       Validate, npm audit (production), gitleaks, actionlint,
+#       Require SHA-pinned actions, commitlint, Dependency review,
+#       License scan (production deps), OSV scan (PR diff) / osv-scan.
+#     Not required (intentional):
+#       - CodeQL: workflow is schedule-only (weekly) + workflow_dispatch;
+#         requiring it would stall every PR.
+#       - OSV scan (full): runs only on push/schedule (reports "skipping"
+#         on PRs). The PR-diff job covers pull_request events.
+#       - salesforce-cla: external check owned by the CLA bot; treat as
+#         advisory, not enforced via ruleset.
 #   - Bypass: repo Admins only (actor_id 5). The release-please auto-merge
 #     job can't bypass the PR rule, so release PRs now require a single
 #     manual merge click from an Admin. Same pattern salesforce/agentscript
@@ -75,7 +82,13 @@ payload=$(cat <<JSON
         "required_status_checks": [
           { "context": "Validate" },
           { "context": "npm audit (production)" },
-          { "context": "gitleaks" }
+          { "context": "gitleaks" },
+          { "context": "actionlint" },
+          { "context": "Require SHA-pinned actions" },
+          { "context": "commitlint" },
+          { "context": "Dependency review" },
+          { "context": "License scan (production deps)" },
+          { "context": "OSV scan (PR diff) / osv-scan" }
         ]
       }
     }


### PR DESCRIPTION
## Summary

Extends the `main protection` ruleset from 3 required checks to 9, after PR #7 demonstrated all of them pass green. Also removes the `paths:` filter on `workflow-lint.yml` so the two jobs it hosts run on every PR (required checks must be able to report on every PR, or the PR cannot be merged).

## Now required

| Check | Added |
|---|---|
| Validate | already required |
| npm audit (production) | already required |
| gitleaks | already required |
| actionlint | **new** |
| Require SHA-pinned actions | **new** |
| commitlint | **new** |
| Dependency review | **new** |
| License scan (production deps) | **new** |
| OSV scan (PR diff) / osv-scan | **new** |

## Intentionally NOT required

| Check | Why |
|---|---|
| CodeQL | weekly schedule only; would stall every PR |
| OSV scan (full) | push/schedule only; reports `skipping` on PRs |
| salesforce-cla | external bot; advisory only |

## Validation

The ruleset has already been updated in place (id `15833380`). This PR is the first one to actually be tested against the new required set — if it goes green, we know the list is correct.

## Reversibility

Remove check names from `scripts/apply-main-ruleset.sh` and re-run. The script updates the existing ruleset in place.