### PR TITLE
fix(ci): correct CODEOWNERS handle to @Jaganpro

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # Comment line immediately above ownership line is reserved for related other information. Please be careful while editing.
 #ECCN:Open Source
 #GUSINFO:
-*                                @jvalaiyapathy
+*                                @Jaganpro
 
 # Per-area owners can be added here as the project grows. For example:
-# /extensions/sf-lsp/             @jvalaiyapathy
-# /extensions/sf-slack/           @jvalaiyapathy
+# /extensions/sf-lsp/             @Jaganpro
+# /extensions/sf-slack/           @Jaganpro


### PR DESCRIPTION
The `@jvalaiyapathy` handle does not exist on GitHub, which causes every release PR (e.g. #11) to be permanently `BLOCKED` by the code-owner-review branch rule.

This updates `.github/CODEOWNERS` to the actual GitHub login `@Jaganpro` so future release PRs can be approved normally instead of requiring an admin bypass merge.