### PR TITLE
feat(sf-llm-gateway-internal): daily activity, token counter, SSO onb…

### DIFF
--- a/catalog/index.json
+++ b/catalog/index.json
@@ -158,7 +158,7 @@
     "entry": "extensions/sf-llm-gateway-internal/index.ts",
     "hasReadme": true,
     "hasTests": true,
-    "srcLoc": 6576
+    "srcLoc": 7383
   },
   {
     "id": "sf-lsp",

--- a/extensions/sf-llm-gateway-internal/index.ts
+++ b/extensions/sf-llm-gateway-internal/index.ts
@@ -181,6 +181,8 @@ import {
 import { migrateGatewaySettings } from "./lib/migrate-unify-provider.ts";
 import { fetchTransformReport, formatTransformReport, type TransformProbe } from "./lib/debug.ts";
 import { fetchGatewayDoctorReport, formatGatewayDoctorReport } from "./lib/doctor.ts";
+import { countTokens, estimateSpend, formatTokenReport } from "./lib/token-counter.ts";
+import { buildOnboardingUrl } from "./lib/onboarding.ts";
 import {
   getMonthlyUsageState,
   refreshMonthlyUsage,
@@ -211,6 +213,8 @@ type CommandArgs = {
     | "debug"
     | "doctor"
     | "usage-probe"
+    | "tokens"
+    | "onboard"
     | "on"
     | "off"
     | "setup";
@@ -246,6 +250,10 @@ function getRuntimeStatusState() {
     health,
     healthError,
     connectionStatus,
+    dailyActivity,
+    dailyActivityError,
+    keyList,
+    keyListError,
   } = getMonthlyUsageState();
   return {
     discovery: getLastDiscovery(),
@@ -256,6 +264,10 @@ function getRuntimeStatusState() {
     health,
     healthError,
     connectionStatus: connectionStatus ?? null,
+    dailyActivity: dailyActivity ?? null,
+    dailyActivityError: dailyActivityError ?? null,
+    keyList: keyList ?? null,
+    keyListError: keyListError ?? null,
     runtimeBetaOverrides: getBetaOverrides(),
     runtimeExtraBetas: getBetaExtras(),
   };
@@ -510,6 +522,10 @@ async function handleCommand(
       return handleDoctorCommand(pi, ctx);
     case "usage-probe":
       return handleUsageProbeCommand(pi, ctx);
+    case "tokens":
+      return handleTokensCommand(pi, ctx, parsed.positional ?? []);
+    case "onboard":
+      return handleOnboardCommand(pi, ctx);
     case "beta":
       return handleBetaCommandImpl(pi, ctx, parsed.betaArgs ?? [], (summary, details, level) =>
         emitCommandOutput(pi, ctx, summary, details, level),
@@ -571,22 +587,49 @@ async function handleUsageProbeCommand(
   ctx: ExtensionCommandContext,
 ): Promise<void> {
   await refreshMonthlyUsage(true, ctx.cwd);
-  const { monthlyUsage, monthlyUsageError, keyInfo, keyInfoError, connectionStatus } =
-    getMonthlyUsageState();
-  const lines = [
+  const {
+    monthlyUsage,
+    monthlyUsageError,
+    keyInfo,
+    keyInfoError,
+    connectionStatus,
+    dailyActivity,
+    dailyActivityError,
+  } = getMonthlyUsageState();
+
+  const lines: string[] = [
     "Gateway usage probe",
     "",
     `Connection: ${connectionStatus?.kind ?? "not checked"}${connectionStatus?.source ? ` via ${connectionStatus.source}` : ""}`,
     `Monthly/user usage: ${monthlyUsage ? `$${monthlyUsage.spend.toFixed(2)} spent${monthlyUsage.budgetResetAt ? `, resets ${monthlyUsage.budgetResetAt}` : ""}` : (monthlyUsageError ?? "not loaded")}`,
     `Current key spend: ${keyInfo ? `$${keyInfo.spend.toFixed(2)}${keyInfo.keyName ? ` on ${keyInfo.keyName}` : ""}` : (keyInfoError ?? "not loaded")}`,
+  ];
+
+  if (dailyActivity) {
+    lines.push(
+      "",
+      `Last ${dailyActivity.entries.length}d activity (${dailyActivity.startDate} → ${dailyActivity.endDate}):`,
+    );
+    for (const e of dailyActivity.entries) {
+      const marker = e.failedRequests > 0 ? " \u26A0" : "";
+      lines.push(
+        `  ${e.date}: $${e.spend.toFixed(4)} across ${e.apiRequests} requests (${e.failedRequests} failed${marker})`,
+      );
+    }
+  } else if (dailyActivityError) {
+    lines.push("", `Daily activity: ${dailyActivityError}`);
+  }
+
+  lines.push(
     "",
     "Conclusion:",
     "- /key/info is key-scoped and can reset when keys rotate.",
     monthlyUsage?.budgetResetAt || monthlyUsage?.budgetDuration
       ? "- /user/info appears user-scoped but budget-windowed, so it is not a lifetime counter."
       : "- /user/info did not prove a true lifetime user counter.",
+    "- /user/daily/activity adds per-day granularity including failed_requests (early-warning signal).",
     "- The welcome splash does not show Lifetime Usage unless a true user-lifetime endpoint exists.",
-  ];
+  );
 
   await emitCommandOutput(
     pi,
@@ -594,6 +637,103 @@ async function handleUsageProbeCommand(
     "SF LLM Gateway Internal usage probe.",
     lines.join("\n"),
     connectionStatus?.kind === "connected" ? "info" : "warning",
+  );
+}
+
+/**
+ * `/sf-llm-gateway-internal tokens <modelId> [prompt]` — count tokens for a
+ * prompt on a specific model and show the gateway’s USD cost estimate. The
+ * gateway tokenizer + pricing are used server-side so callers avoid shipping
+ * a local tokenizer that drifts from upstream.
+ *
+ * When no prompt is provided we use a short canned probe so users get a sane
+ * sanity check by typing just `/sf-llm-gateway-internal tokens gpt-5`.
+ */
+/**
+ * `/sf-llm-gateway-internal onboard` — print a one-click SSO URL that lands
+ * the user on the Virtual Keys tab of the admin UI. Falls back to a
+ * friendly warning when no base URL is configured yet, since the onboarding
+ * link is derived from the gateway root.
+ */
+async function handleOnboardCommand(pi: ExtensionAPI, ctx: ExtensionCommandContext): Promise<void> {
+  const config = getGatewayConfig(ctx.cwd);
+  const url = buildOnboardingUrl(config.baseUrl);
+  if (!url) {
+    await emitCommandOutput(
+      pi,
+      ctx,
+      "SF LLM Gateway Internal onboard — base URL is not configured.",
+      [
+        `Run /${COMMAND_NAME} setup to enter the gateway base URL first, then rerun this command.`,
+        `Env-var fallback for automation: ${BASE_URL_ENV}.`,
+      ].join("\n"),
+      "warning",
+    );
+    return;
+  }
+
+  const report = [
+    "Open this link to create a new gateway API key:",
+    "",
+    url,
+    "",
+    "Flow:",
+    "1. Your browser opens the gateway SSO login.",
+    "2. After sign-in you land on the admin UI's Virtual Keys tab.",
+    "3. Click `+ Create New Key`, copy the value.",
+    `4. Paste into pi's /login (or \`/${COMMAND_NAME} setup\`) to save it.`,
+  ].join("\n");
+
+  await emitCommandOutput(pi, ctx, "SF LLM Gateway Internal onboarding link.", report, "info");
+}
+
+async function handleTokensCommand(
+  pi: ExtensionAPI,
+  ctx: ExtensionCommandContext,
+  args: string[],
+): Promise<void> {
+  if (args.length === 0) {
+    await emitCommandOutput(
+      pi,
+      ctx,
+      "SF LLM Gateway Internal tokens — missing model id.",
+      [
+        `Usage: /${COMMAND_NAME} tokens <modelId> [prompt words here]`,
+        "",
+        "Examples:",
+        `  /${COMMAND_NAME} tokens gpt-5 Hello world how are you today`,
+        `  /${COMMAND_NAME} tokens claude-opus-4-7`,
+      ].join("\n"),
+      "warning",
+    );
+    return;
+  }
+
+  const [modelId, ...promptTokens] = args;
+  if (!modelId) {
+    ctx.ui.notify(`Usage: /${COMMAND_NAME} tokens <modelId> [prompt]`, "warning");
+    return;
+  }
+  const prompt =
+    promptTokens.length > 0
+      ? promptTokens.join(" ")
+      : "Hello world — sanity probe from /sf-llm-gateway-internal tokens.";
+
+  const [tokensResult, spendResult] = await Promise.all([
+    countTokens(ctx.cwd, { model: modelId, prompt }),
+    estimateSpend(ctx.cwd, { model: modelId, prompt }),
+  ]);
+
+  const report = [formatTokenReport(tokensResult, spendResult), "", `Prompt: ${prompt}`].join("\n");
+
+  await emitCommandOutput(
+    pi,
+    ctx,
+    tokensResult.ok
+      ? `Token count for ${modelId}.`
+      : `Token count failed: ${tokensResult.error ?? "unknown error"}`,
+    report,
+    tokensResult.ok ? "info" : "warning",
   );
 }
 
@@ -732,6 +872,8 @@ async function handleHelpCommand(pi: ExtensionAPI, ctx: ExtensionCommandContext)
     `- /${COMMAND_NAME} models`,
     `- /${COMMAND_NAME} doctor`,
     `- /${COMMAND_NAME} usage-probe`,
+    `- /${COMMAND_NAME} tokens <modelId> [prompt]`,
+    `- /${COMMAND_NAME} onboard    # SSO deep-link to create a new gateway key`,
     `- /${COMMAND_NAME} debug <modelId> [reasoning=<level>] [tool] [adaptive]`,
     `- /${COMMAND_NAME} beta`,
     `- /${COMMAND_NAME} beta <name> on|off`,
@@ -802,6 +944,12 @@ export function parseCommandArgs(args: string): CommandArgs {
   }
   if (sub === "debug") {
     return { subcommand: "debug", scope, positional: tokens.slice(1) };
+  }
+  if (sub === "tokens" || sub === "count") {
+    return { subcommand: "tokens", scope, positional: tokens.slice(1) };
+  }
+  if (sub === "onboard") {
+    return { subcommand: "onboard", scope };
   }
   return { subcommand: "status", scope };
 }

--- a/extensions/sf-llm-gateway-internal/lib/discovery.ts
+++ b/extensions/sf-llm-gateway-internal/lib/discovery.ts
@@ -67,9 +67,13 @@ import {
   ALWAYS_INCLUDE_MODEL_IDS,
   buildBootstrapModelList,
   buildDiscoveredModelList,
+  diffModelGroupProviders,
+  fetchGatewayModelGroupInfo,
   fetchGatewayModelIds,
   fetchGatewayModelInfoMap,
   isAnthropicModelId,
+  type GatewayModelGroupInfoMap,
+  type ModelGroupDrift,
   type TaggedGatewayModel,
 } from "./models.ts";
 import { streamSfGatewayAnthropic, streamSfGatewayOpenAI } from "./transport.ts";
@@ -84,8 +88,27 @@ export interface GatewayDiscoveryState {
 let lastDiscovery: GatewayDiscoveryState | null = null;
 let discoveryInFlight: Promise<GatewayDiscoveryState> | null = null;
 
+/**
+ * Most-recent `/model_group/info` snapshot. Captured at discovery time so
+ * subsequent discoveries can diff against it without re-fetching. The
+ * first snapshot seeds `lastModelGroupDrift = []` (no drift — baseline).
+ */
+let lastModelGroupInfo: GatewayModelGroupInfoMap | null = null;
+let lastModelGroupDrift: ModelGroupDrift[] = [];
+
 export function getLastDiscovery(): GatewayDiscoveryState | null {
   return lastDiscovery;
+}
+
+/** Current provider-drift snapshot. Empty on the first discovery. */
+export function getLastModelGroupDrift(): ModelGroupDrift[] {
+  return lastModelGroupDrift;
+}
+
+/** Test-only: reset drift state between cases. */
+export function __resetModelGroupDriftForTests(): void {
+  lastModelGroupInfo = null;
+  lastModelGroupDrift = [];
 }
 
 /**
@@ -288,13 +311,25 @@ export async function discoverAndRegister(
     }
 
     try {
-      // Pull /v1/models and /v1/model/info in parallel. The info endpoint is
-      // optional enrichment — failures resolve to an empty map and the
-      // catalog keeps working with inference defaults.
-      const [allIds, modelInfoMap] = await Promise.all([
+      // Pull /v1/models, /v1/model/info and /model_group/info in parallel.
+      // The info endpoints are optional enrichment — failures resolve to an
+      // empty map and the catalog keeps working with inference defaults.
+      // `/model_group/info` powers provider-drift detection in status.ts;
+      // its result is compared to the previous session's snapshot so a
+      // silent admin reroute surfaces as a warning line.
+      const [allIds, modelInfoMap, modelGroupInfo] = await Promise.all([
         fetchGatewayModelIds(config.baseUrl, config.apiKey),
         fetchGatewayModelInfoMap(config.baseUrl, config.apiKey),
+        fetchGatewayModelGroupInfo(config.baseUrl, config.apiKey),
       ]);
+
+      // Diff against the previous snapshot (same-session or restored from
+      // the previous `discoverAndRegister`). First run seeds the baseline
+      // with an empty drift array.
+      lastModelGroupDrift = lastModelGroupInfo
+        ? diffModelGroupProviders(lastModelGroupInfo, modelGroupInfo)
+        : [];
+      lastModelGroupInfo = modelGroupInfo;
 
       if (allIds.length === 0) {
         registerProviderIfConfigured(pi, runtimeBetaOverrides, runtimeExtraBetas, cwd);

--- a/extensions/sf-llm-gateway-internal/lib/doctor.ts
+++ b/extensions/sf-llm-gateway-internal/lib/doctor.ts
@@ -34,7 +34,12 @@ export type GatewayDoctorReport = {
 };
 
 export function interpretGatewayHttpResult(status: number, bodyPreview: string): string {
-  if (status >= 200 && status < 300) return "OK";
+  if (status >= 200 && status < 300) {
+    if (/server_root_path|proxy_base_url/.test(bodyPreview)) {
+      return "OK (LiteLLM proxy signature)";
+    }
+    return "OK";
+  }
   if (status === 401 && /key is blocked/i.test(bodyPreview)) {
     return "Authentication failed because the active gateway key is blocked. Run /login and paste a new gateway API key; saved pi config now takes precedence over stale env or Keychain exports.";
   }
@@ -66,6 +71,18 @@ export async function fetchGatewayDoctorReport(cwd: string): Promise<GatewayDoct
   const anthropicRootUrl = config.baseUrl ? toGatewayRootBaseUrl(config.baseUrl) : undefined;
   const checks: GatewayDoctorCheck[] = [];
 
+  if (anthropicRootUrl) {
+    // Un-authenticated signature check. Runs before the authenticated probes
+    // so misconfigured base URLs (e.g. SSO portal pasted instead of the API
+    // gateway) are called out before the first 401.
+    checks.push(
+      await runGatewayCheck(
+        "Gateway signature",
+        `${anthropicRootUrl}/.well-known/litellm-ui-config`,
+        undefined,
+      ),
+    );
+  }
   if (openAiBaseUrl) {
     checks.push(await runGatewayCheck("Model discovery", `${openAiBaseUrl}/models`, config.apiKey));
   }
@@ -106,6 +123,39 @@ export async function fetchGatewayDoctorReport(cwd: string): Promise<GatewayDoct
     checks,
     recommendations,
   };
+}
+
+/**
+ * Minimal liveness probe used by the footer refresher to confirm the
+ * gateway is reachable without the 450-byte readiness payload. Returns
+ * true when `GET /test` responds `{route: "/test"}` and the endpoint is
+ * open to API-token auth.
+ *
+ * Exported so non-doctor code paths (e.g. monthly-usage refresh) can reuse
+ * the same interpretation without duplicating the fetch boilerplate.
+ */
+export async function pingGateway(
+  baseUrlRoot: string,
+  apiKey: string | undefined,
+  timeoutMs: number = DOCTOR_TIMEOUT_MS,
+): Promise<{ ok: boolean; status?: number; error?: string }> {
+  try {
+    const response = await fetchWithTimeout(
+      `${baseUrlRoot}/test`,
+      {
+        method: "GET",
+        headers: {
+          ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+          "Content-Type": "application/json",
+        },
+        redirect: "manual",
+      },
+      timeoutMs,
+    );
+    return { ok: response.ok, status: response.status };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
 }
 
 async function runGatewayCheck(

--- a/extensions/sf-llm-gateway-internal/lib/models.ts
+++ b/extensions/sf-llm-gateway-internal/lib/models.ts
@@ -29,7 +29,7 @@
 
 import type { ProviderModelConfig } from "@mariozechner/pi-coding-agent";
 import { DEFAULT_MODEL_ID, FALLBACK_MODEL_ID, PREVIOUS_DEFAULT_MODEL_ID } from "./config.ts";
-import { toGatewayOpenAiBaseUrl } from "./gateway-url.ts";
+import { toGatewayOpenAiBaseUrl, toGatewayRootBaseUrl } from "./gateway-url.ts";
 import { ANTHROPIC_FINE_GRAINED_TOOL_STREAMING_BETA } from "./transport.ts";
 
 // -------------------------------------------------------------------------------------------------
@@ -255,6 +255,21 @@ export interface GatewayModelInfo {
  * override inference defaults when a preset does not already cover the model.
  */
 export type GatewayModelInfoMap = Record<string, GatewayModelInfo>;
+
+/**
+ * Per-model-group metadata from `/model_group/info`. Complements
+ * `/v1/model/info` with the upstream `providers` array — the list of cloud
+ * providers the gateway admin has registered behind a given model group.
+ * The extension snapshots this at session_start and watches for drift so a
+ * silent admin reroute (e.g. adding an `anthropic` backing to a group that
+ * was `bedrock`-only) can be surfaced in the status report.
+ */
+export interface GatewayModelGroupInfo {
+  modelGroup: string;
+  providers: string[];
+}
+
+export type GatewayModelGroupInfoMap = Record<string, GatewayModelGroupInfo>;
 
 // -------------------------------------------------------------------------------------------------
 // Static model catalog (presets for known models)
@@ -1003,6 +1018,85 @@ export async function fetchGatewayModelInfoMap(
   } catch {
     return {};
   }
+}
+
+/**
+ * Fetch the `/model_group/info` snapshot, collapsed to `{group -> providers[]}`.
+ * Failures are swallowed so this enrichment is strictly optional — the
+ * extension must keep working when the gateway admin disables the
+ * endpoint or the request times out.
+ *
+ * The upstream shape is an array of records with `model_group` and
+ * `providers: string[]`. The map is ready for provider-drift diffing by
+ * the discovery layer.
+ */
+export async function fetchGatewayModelGroupInfo(
+  baseUrl: string,
+  apiKey: string,
+): Promise<GatewayModelGroupInfoMap> {
+  try {
+    const response = await fetchWithTimeout(
+      `${toGatewayRootBaseUrl(baseUrl)}/model_group/info`,
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+      },
+      MODEL_FETCH_TIMEOUT_MS,
+    );
+
+    if (!response.ok) return {};
+
+    const json = (await response.json()) as {
+      data?: Array<{
+        model_group?: string;
+        providers?: unknown;
+      }>;
+    };
+
+    const map: GatewayModelGroupInfoMap = {};
+    for (const entry of json.data || []) {
+      const group = typeof entry.model_group === "string" ? entry.model_group.trim() : "";
+      if (!group) continue;
+      const providers = Array.isArray(entry.providers)
+        ? entry.providers.filter((p): p is string => typeof p === "string").sort()
+        : [];
+      map[group] = { modelGroup: group, providers };
+    }
+    return map;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Compare two model-group snapshots and return the set of groups whose
+ * providers changed. Each entry carries the old and new arrays so the
+ * caller can format a readable drift message. Pure function, exported for
+ * unit tests.
+ */
+export interface ModelGroupDrift {
+  modelGroup: string;
+  previousProviders: string[];
+  currentProviders: string[];
+}
+
+export function diffModelGroupProviders(
+  previous: GatewayModelGroupInfoMap,
+  current: GatewayModelGroupInfoMap,
+): ModelGroupDrift[] {
+  const groups = new Set<string>([...Object.keys(previous), ...Object.keys(current)]);
+  const drift: ModelGroupDrift[] = [];
+  for (const group of groups) {
+    const prev = previous[group]?.providers ?? [];
+    const curr = current[group]?.providers ?? [];
+    if (prev.length !== curr.length || prev.some((p, i) => p !== curr[i])) {
+      drift.push({ modelGroup: group, previousProviders: prev, currentProviders: curr });
+    }
+  }
+  return drift.sort((a, b) => a.modelGroup.localeCompare(b.modelGroup));
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/extensions/sf-llm-gateway-internal/lib/monthly-usage.ts
+++ b/extensions/sf-llm-gateway-internal/lib/monthly-usage.ts
@@ -18,8 +18,11 @@
  */
 import type {
   GatewayConnectionStatus,
+  GatewayDailyActivity,
+  GatewayDailyActivityEntry,
   GatewayHealth,
   GatewayKeyInfo,
+  GatewayKeyList,
   GatewayMonthlyUsage,
   MonthlyUsageSnapshot,
 } from "../../../lib/common/monthly-usage/store.ts";
@@ -44,10 +47,20 @@ const FETCH_TIMEOUT_MS = 10_000;
 // reaching into lib/common directly.
 export type {
   GatewayConnectionStatus,
+  GatewayDailyActivity,
+  GatewayDailyActivityEntry,
   GatewayHealth,
   GatewayKeyInfo,
+  GatewayKeyList,
   GatewayMonthlyUsage,
 } from "../../../lib/common/monthly-usage/store.ts";
+
+/**
+ * Default daily-activity window. Seven days is enough to spot a bad day
+ * next to a healthy baseline but small enough that `/user/daily/activity`
+ * responds in ~150ms on this gateway.
+ */
+const DAILY_ACTIVITY_DEFAULT_DAYS = 7;
 
 export { getMonthlyUsageState };
 
@@ -116,14 +129,19 @@ export async function refreshMonthlyUsage(force: boolean, cwd: string): Promise<
       return;
     }
 
-    // Fire all three in parallel. Each branch resolves to either the parsed
+    // Fire all four in parallel. Each branch resolves to either the parsed
     // payload or a recorded error — a single slow endpoint must not stall
-    // the others.
-    const [usageResult, keyResult, healthResult] = await Promise.allSettled([
-      fetchMonthlyUsage(config.baseUrl, config.apiKey),
-      fetchKeyInfo(config.baseUrl, config.apiKey),
-      fetchHealth(config.baseUrl, config.apiKey),
-    ]);
+    // the others. Daily activity is additive: a failure here does not
+    // downgrade the connection-status classification, which is gated on
+    // the three primary probes (user-info, key-info, health).
+    const [usageResult, keyResult, healthResult, dailyResult, keyListResult] =
+      await Promise.allSettled([
+        fetchMonthlyUsage(config.baseUrl, config.apiKey),
+        fetchKeyInfo(config.baseUrl, config.apiKey),
+        fetchHealth(config.baseUrl, config.apiKey),
+        fetchDailyActivity(config.baseUrl, config.apiKey, DAILY_ACTIVITY_DEFAULT_DAYS),
+        fetchKeyList(config.baseUrl, config.apiKey),
+      ]);
 
     const snapshot: MonthlyUsageSnapshot = {
       monthlyUsage: null,
@@ -133,6 +151,10 @@ export async function refreshMonthlyUsage(force: boolean, cwd: string): Promise<
       health: null,
       healthError: null,
       connectionStatus: null,
+      dailyActivity: null,
+      dailyActivityError: null,
+      keyList: null,
+      keyListError: null,
     };
 
     if (usageResult.status === "fulfilled") {
@@ -158,6 +180,24 @@ export async function refreshMonthlyUsage(force: boolean, cwd: string): Promise<
         healthResult.reason instanceof Error
           ? healthResult.reason.message
           : String(healthResult.reason);
+    }
+
+    if (dailyResult.status === "fulfilled") {
+      snapshot.dailyActivity = dailyResult.value;
+    } else {
+      snapshot.dailyActivityError =
+        dailyResult.reason instanceof Error
+          ? dailyResult.reason.message
+          : String(dailyResult.reason);
+    }
+
+    if (keyListResult.status === "fulfilled") {
+      snapshot.keyList = keyListResult.value;
+    } else {
+      snapshot.keyListError =
+        keyListResult.reason instanceof Error
+          ? keyListResult.reason.message
+          : String(keyListResult.reason);
     }
 
     snapshot.connectionStatus = resolveConnectionStatus(usageResult, keyResult, healthResult);
@@ -407,4 +447,129 @@ async function fetchHealth(baseUrl: string, apiKey: string): Promise<GatewayHeal
     lastUpdated: typeof json.last_updated === "string" ? json.last_updated : undefined,
     fetchedAt: new Date().toISOString(),
   };
+}
+
+/**
+ * Fetch per-day activity metrics for the authenticated user from
+ * `/user/daily/activity`. Covers `[today - days + 1, today]` (inclusive of
+ * both boundaries) so a 7-day range returns up to seven entries including
+ * the current day-in-progress.
+ *
+ * The gateway accepts the request from a non-admin `internal_user_viewer`
+ * key and scopes results to the current user, so no extra role is required.
+ * Returns a normalized `GatewayDailyActivity` sorted ascending by date.
+ *
+ * Exported for unit tests and the `usage-probe` command; production code
+ * reaches it through the parallel refresh above.
+ */
+export async function fetchDailyActivity(
+  baseUrl: string,
+  apiKey: string,
+  days: number,
+): Promise<GatewayDailyActivity> {
+  const clampedDays = Math.max(1, Math.min(30, Math.floor(days)));
+  const end = new Date();
+  const start = new Date(end);
+  start.setUTCDate(end.getUTCDate() - (clampedDays - 1));
+  const startDate = toIsoDate(start);
+  const endDate = toIsoDate(end);
+
+  const url =
+    `${toGatewayRootBaseUrl(baseUrl)}/user/daily/activity` +
+    `?start_date=${startDate}&end_date=${endDate}`;
+
+  const response = await fetchWithTimeout(
+    url,
+    {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+    },
+    FETCH_TIMEOUT_MS,
+  );
+
+  if (!response.ok) {
+    throw await gatewayRequestError("Daily activity", "daily-activity", response);
+  }
+
+  const json = (await response.json()) as {
+    results?: Array<{
+      date?: string;
+      metrics?: Record<string, unknown>;
+    }>;
+  };
+
+  const entries: GatewayDailyActivityEntry[] = [];
+  for (const row of json.results ?? []) {
+    if (typeof row.date !== "string") continue;
+    const m = row.metrics ?? {};
+    entries.push({
+      date: row.date,
+      spend: numberOr(m.spend, 0),
+      promptTokens: numberOr(m.prompt_tokens, 0),
+      completionTokens: numberOr(m.completion_tokens, 0),
+      cacheReadInputTokens: numberOr(m.cache_read_input_tokens, 0),
+      cacheCreationInputTokens: numberOr(m.cache_creation_input_tokens, 0),
+      totalTokens: numberOr(m.total_tokens, 0),
+      successfulRequests: numberOr(m.successful_requests, 0),
+      failedRequests: numberOr(m.failed_requests, 0),
+      apiRequests: numberOr(m.api_requests, 0),
+    });
+  }
+  entries.sort((a, b) => a.date.localeCompare(b.date));
+
+  return {
+    entries,
+    startDate,
+    endDate,
+    fetchedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Fetch the number of keys this user owns on the gateway via `/key/list`.
+ * Accepts `internal_user_viewer` role. The endpoint returns an array of
+ * hashed key ids; this function only surfaces the count so no sensitive
+ * material is stored or logged.
+ *
+ * Exported for unit tests.
+ */
+export async function fetchKeyList(baseUrl: string, apiKey: string): Promise<GatewayKeyList> {
+  const response = await fetchWithTimeout(
+    `${toGatewayRootBaseUrl(baseUrl)}/key/list`,
+    {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+    },
+    FETCH_TIMEOUT_MS,
+  );
+
+  if (!response.ok) {
+    throw await gatewayRequestError("Key list", "key-list", response);
+  }
+
+  const json = (await response.json()) as {
+    keys?: unknown[];
+    total_count?: number;
+  };
+  const count =
+    typeof json.total_count === "number"
+      ? json.total_count
+      : Array.isArray(json.keys)
+        ? json.keys.length
+        : 0;
+  return { count, fetchedAt: new Date().toISOString() };
+}
+
+function toIsoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function numberOr(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
 }

--- a/extensions/sf-llm-gateway-internal/lib/onboarding.ts
+++ b/extensions/sf-llm-gateway-internal/lib/onboarding.ts
@@ -1,0 +1,53 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/**
+ * Onboarding deep-link builder for the gateway extension.
+ *
+ * The gateway sits behind SSO. Hitting `/oauth2/start` kicks off the SSO
+ * dance and lands the user back on a post-login destination. Live-verified
+ * against this gateway deployment, the only query param that overrides the
+ * default post-login target is `rd=` (`next=` and `redirect=` are ignored).
+ *
+ * `<baseUrl>/oauth2/start?rd=/ui/?page=api-keys` → SSO → `/oauth2/callback`
+ *   → LiteLLM session cookie → `/ui/?page=api-keys` (Virtual Keys tab).
+ *
+ * Users click `+ Create New Key`, copy the value, paste into pi's `/login`.
+ * Single round trip, zero context switching between docs and the UI.
+ *
+ * Pure functions only: callers pass in the base URL, we return strings.
+ * This module has no side effects so it is safe to exercise from unit tests
+ * without mocking the browser or the identity provider.
+ */
+import { toGatewayRootBaseUrl } from "./gateway-url.ts";
+
+/**
+ * Named targets inside the LiteLLM admin UI. The SPA interprets these as
+ * `?page=<key>` client-side, so they work even though the server returns
+ * the same shell HTML regardless of the query. Add new targets here
+ * sparingly \u2014 any drift from the upstream LiteLLM UI would send users to
+ * an error page.
+ */
+export const OnboardingTarget = {
+  ApiKeys: "api-keys",
+} as const;
+
+export type OnboardingTarget = (typeof OnboardingTarget)[keyof typeof OnboardingTarget];
+
+/**
+ * Build a one-click URL that takes the user through the gateway's SSO and
+ * lands them on the requested LiteLLM admin UI tab. Returns an empty string
+ * when `baseUrl` is missing so callers can treat "no configured base URL" as
+ * "nothing to open" without throwing.
+ */
+export function buildOnboardingUrl(
+  baseUrl: string | undefined,
+  target: OnboardingTarget = OnboardingTarget.ApiKeys,
+): string {
+  if (!baseUrl) return "";
+  const root = toGatewayRootBaseUrl(baseUrl);
+  if (!root) return "";
+  // `rd` is the only param honored by this LiteLLM build; the value is URL-
+  // encoded inside the IdP's OAuth `state` so any path is fine here. Embed
+  // `?page=<target>` directly so callers don't have to think about SPA
+  // routing.
+  return `${root}/oauth2/start?rd=/ui/?page=${encodeURIComponent(target)}`;
+}

--- a/extensions/sf-llm-gateway-internal/lib/status.ts
+++ b/extensions/sf-llm-gateway-internal/lib/status.ts
@@ -25,11 +25,14 @@ import {
   getActiveModelDefinition,
   isDefaultAnthropicBeta,
 } from "./models.ts";
-import type { GatewayDiscoveryState } from "./discovery.ts";
+import { getLastModelGroupDrift, type GatewayDiscoveryState } from "./discovery.ts";
+import type { ModelGroupDrift } from "./models.ts";
 import type {
   GatewayConnectionStatus,
+  GatewayDailyActivity,
   GatewayHealth,
   GatewayKeyInfo,
+  GatewayKeyList,
   GatewayMonthlyUsage,
 } from "./monthly-usage.ts";
 import { formatProviderSignalBadge, getActiveProviderSignal } from "./provider-telemetry.ts";
@@ -50,6 +53,10 @@ export interface GatewayRuntimeStatusState {
   health: GatewayHealth | null;
   healthError: string | null;
   connectionStatus?: GatewayConnectionStatus | null;
+  dailyActivity?: GatewayDailyActivity | null;
+  dailyActivityError?: string | null;
+  keyList?: GatewayKeyList | null;
+  keyListError?: string | null;
   runtimeBetaOverrides: Set<string> | null;
   runtimeExtraBetas: Set<string>;
 }
@@ -97,9 +104,12 @@ export function buildStatusReport(
     `Key spend: ${formatKeyInfoReportLine(state.keyInfo, state.keyInfoError)}`,
     `Gateway connection: ${formatConnectionReportLine(state.connectionStatus)}`,
     `Gateway health: ${formatHealthReportLine(state.health, state.healthError)}`,
+    `Last 7d: ${formatDailyActivityReportLine(state.dailyActivity, state.dailyActivityError)}`,
+    `Keys on account: ${formatKeyListReportLine(state.keyList, state.keyListError, state.keyInfo?.keyName)}`,
     "",
     `Model discovery: ${discovery?.source ?? "not run"}${discovery?.error ? ` ⚠ ${discovery.error}` : ""}`,
     `Discovered models: ${discovery?.modelIds.length ?? 0}`,
+    ...formatModelGroupDriftLines(getLastModelGroupDrift()),
     "",
     "Anthropic beta headers:",
     ...KNOWN_BETAS.map((beta) => {
@@ -229,6 +239,92 @@ function formatHealthReportLine(health: GatewayHealth | null, healthError: strin
     return parts.join(", ");
   }
   return healthError ?? "not loaded yet";
+}
+
+/**
+ * One-line rollup of daily activity for the status report. Combines total
+ * spend, request totals, failure count, and a per-day sparkline so users
+ * can see a bad day next to healthy baseline at a glance.
+ *
+ * Exported for unit tests and the usage-probe renderer.
+ */
+export function formatDailyActivityReportLine(
+  dailyActivity: GatewayDailyActivity | null | undefined,
+  dailyActivityError: string | null | undefined,
+): string {
+  if (!dailyActivity) return dailyActivityError ?? "not loaded yet";
+  const entries = dailyActivity.entries;
+  if (entries.length === 0) return "no activity in window";
+
+  let totalSpend = 0;
+  let totalRequests = 0;
+  let totalFailed = 0;
+  for (const e of entries) {
+    totalSpend += e.spend;
+    totalRequests += e.apiRequests;
+    totalFailed += e.failedRequests;
+  }
+
+  const warn = totalFailed > 0 ? " \u26A0" : "";
+  return (
+    `${formatUsd(totalSpend)} across ${totalRequests} requests (${totalFailed} failed${warn}) ` +
+    `| spend: ${formatSparkline(entries.map((e) => e.spend))}`
+  );
+}
+
+/**
+ * Render the `/key/list` count line for the status report. Mentions the
+ * currently-active key's masked name when `keyInfo.keyName` is available
+ * so users can cross-check against what the gateway admin UI shows.
+ *
+ * Exported for unit tests.
+ */
+export function formatKeyListReportLine(
+  keyList: GatewayKeyList | null | undefined,
+  keyListError: string | null | undefined,
+  activeKeyName?: string,
+): string {
+  if (!keyList) return keyListError ?? "not loaded yet";
+  const activeHint = activeKeyName ? `, active: ${activeKeyName}` : "";
+  if (keyList.count <= 1) return `${keyList.count}${activeHint}`;
+  return `${keyList.count} (consider pruning unused ones in /ui/${activeHint})`;
+}
+
+/**
+ * Render provider-drift warnings from the last discovery diff. Returns an
+ * empty array when the model-group providers array is unchanged so callers
+ * can spread into the report without any conditional glue.
+ *
+ * Exported for unit tests.
+ */
+export function formatModelGroupDriftLines(drift: ModelGroupDrift[]): string[] {
+  if (drift.length === 0) return [];
+  const out: string[] = ["Model-group provider drift:"];
+  for (const d of drift) {
+    const prev = d.previousProviders.length ? d.previousProviders.join(", ") : "(none)";
+    const curr = d.currentProviders.length ? d.currentProviders.join(", ") : "(none)";
+    out.push(`  ⚠ ${d.modelGroup}: [${prev}] → [${curr}]`);
+  }
+  return out;
+}
+
+/**
+ * Render a Unicode block sparkline for a numeric series. Empty arrays and
+ * all-zero arrays are represented with a single empty block so the status
+ * line stays aligned across days. Tested via snapshot in status.test.ts.
+ */
+export function formatSparkline(values: number[]): string {
+  if (values.length === 0) return "";
+  const max = Math.max(...values);
+  if (max <= 0) return values.map(() => "\u2581").join("");
+  const bars = ["\u2581", "\u2582", "\u2583", "\u2584", "\u2585", "\u2586", "\u2587", "\u2588"];
+  return values
+    .map((v) => {
+      if (v <= 0) return bars[0];
+      const idx = Math.min(bars.length - 1, Math.floor((v / max) * (bars.length - 1)));
+      return bars[idx];
+    })
+    .join("");
 }
 
 function isKnownBetaActive(value: string, state: GatewayRuntimeStatusState): boolean {

--- a/extensions/sf-llm-gateway-internal/lib/token-counter.ts
+++ b/extensions/sf-llm-gateway-internal/lib/token-counter.ts
@@ -1,0 +1,230 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/**
+ * Gateway-backed token counting and cost estimation.
+ *
+ * Two endpoints power this:
+ *   - `POST /utils/token_counter` → `{ total_tokens, model_used, tokenizer_type }`
+ *   - `POST /spend/calculate`     → `{ cost: <usd> }`
+ *
+ * Neither invokes a real completion, so probes are free. Both accept the
+ * same `{ model, messages | prompt }` shape and route internally based on
+ * which field is present. This module exposes them as small pure async
+ * helpers that the `/sf-llm-gateway-internal tokens` command composes into
+ * a single report.
+ *
+ * Pure functions, no runtime state. All failures are encoded in the
+ * returned value so the command handler can stay linear and render
+ * consistent output whether the gateway is healthy, slow, or 401.
+ */
+import { API_KEY_ENV, getGatewayConfig } from "./config.ts";
+import { toGatewayRootBaseUrl } from "./gateway-url.ts";
+import { fetchWithTimeout } from "./models.ts";
+
+const TOKEN_COUNT_TIMEOUT_MS = 8_000;
+
+export interface TokenCountResult {
+  ok: boolean;
+  model: string;
+  totalTokens?: number;
+  modelUsed?: string;
+  tokenizerType?: string;
+  error?: string;
+}
+
+export interface SpendEstimateResult {
+  ok: boolean;
+  model: string;
+  /** Estimated cost in USD, e.g. `0.00001`. */
+  costUsd?: number;
+  error?: string;
+}
+
+export interface TokenProbeInput {
+  model: string;
+  /** Raw prompt. Preferred for quick CLI probes. */
+  prompt?: string;
+  /** Full messages array. Preferred for "what would this session cost" probes. */
+  messages?: Array<{ role: string; content: string }>;
+}
+
+/**
+ * Count tokens for a prompt or messages array on a given gateway model.
+ *
+ * Sends `{model, prompt}` when only `prompt` is provided, otherwise sends
+ * `{model, messages}`. The gateway picks the right tokenizer for the model
+ * (see `tokenizerType` in the result) so callers do not need to ship a
+ * local tokenizer that drifts from upstream.
+ */
+export async function countTokens(cwd: string, input: TokenProbeInput): Promise<TokenCountResult> {
+  const config = getGatewayConfig(cwd);
+  if (!config.baseUrl) {
+    return { ok: false, model: input.model, error: "Missing gateway base URL." };
+  }
+  if (!config.apiKey) {
+    return { ok: false, model: input.model, error: `Missing ${API_KEY_ENV} or saved API key.` };
+  }
+
+  const body: Record<string, unknown> = { model: input.model };
+  if (input.messages && input.messages.length > 0) {
+    body.messages = input.messages;
+  } else if (typeof input.prompt === "string") {
+    body.prompt = input.prompt;
+  } else {
+    return { ok: false, model: input.model, error: "Provide either prompt or messages." };
+  }
+
+  const url = `${toGatewayRootBaseUrl(config.baseUrl)}/utils/token_counter`;
+  try {
+    const response = await fetchWithTimeout(
+      url,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${config.apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      },
+      TOKEN_COUNT_TIMEOUT_MS,
+    );
+
+    if (!response.ok) {
+      return {
+        ok: false,
+        model: input.model,
+        error: `token_counter returned ${response.status}.`,
+      };
+    }
+
+    const json = (await response.json()) as {
+      total_tokens?: number;
+      model_used?: string;
+      tokenizer_type?: string;
+    };
+    if (typeof json.total_tokens !== "number") {
+      return {
+        ok: false,
+        model: input.model,
+        error: "token_counter response missing total_tokens.",
+      };
+    }
+    return {
+      ok: true,
+      model: input.model,
+      totalTokens: json.total_tokens,
+      modelUsed: json.model_used,
+      tokenizerType: json.tokenizer_type,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      model: input.model,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * Estimate the dollar cost of sending a prompt or messages array through a
+ * gateway model. Wraps `/spend/calculate`, which performs token counting +
+ * per-model price lookup server-side and returns a USD figure. Returns
+ * zero for no-cost models (e.g. unpriced entries in `/v1/model/info`).
+ *
+ * The endpoint requires `{model, messages}`; we always send `messages` and
+ * wrap a bare prompt into a synthetic user message for convenience.
+ */
+export async function estimateSpend(
+  cwd: string,
+  input: TokenProbeInput,
+): Promise<SpendEstimateResult> {
+  const config = getGatewayConfig(cwd);
+  if (!config.baseUrl) {
+    return { ok: false, model: input.model, error: "Missing gateway base URL." };
+  }
+  if (!config.apiKey) {
+    return { ok: false, model: input.model, error: `Missing ${API_KEY_ENV} or saved API key.` };
+  }
+
+  const messages =
+    input.messages && input.messages.length > 0
+      ? input.messages
+      : typeof input.prompt === "string"
+        ? [{ role: "user", content: input.prompt }]
+        : undefined;
+  if (!messages) {
+    return { ok: false, model: input.model, error: "Provide either prompt or messages." };
+  }
+
+  const url = `${toGatewayRootBaseUrl(config.baseUrl)}/spend/calculate`;
+  try {
+    const response = await fetchWithTimeout(
+      url,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${config.apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ model: input.model, messages }),
+      },
+      TOKEN_COUNT_TIMEOUT_MS,
+    );
+
+    if (!response.ok) {
+      return {
+        ok: false,
+        model: input.model,
+        error: `spend/calculate returned ${response.status}.`,
+      };
+    }
+
+    const json = (await response.json()) as { cost?: number };
+    if (typeof json.cost !== "number") {
+      return { ok: false, model: input.model, error: "spend/calculate response missing cost." };
+    }
+    return { ok: true, model: input.model, costUsd: json.cost };
+  } catch (error) {
+    return {
+      ok: false,
+      model: input.model,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * Render a combined token-count + spend-estimate report for the
+ * `/sf-llm-gateway-internal tokens` command. Kept as a pure formatter so
+ * the command handler can stay thin and tests can assert exact text.
+ */
+export function formatTokenReport(tokens: TokenCountResult, spend: SpendEstimateResult): string {
+  const lines: string[] = [];
+  if (tokens.ok) {
+    const tokenizer = tokens.tokenizerType ? ` using ${tokens.tokenizerType}` : "";
+    const routed =
+      tokens.modelUsed && tokens.modelUsed !== tokens.model
+        ? ` (routed to ${tokens.modelUsed})`
+        : "";
+    lines.push(`Tokens: ${tokens.totalTokens}${tokenizer} on ${tokens.model}${routed}`);
+  } else {
+    lines.push(`Tokens: ${tokens.error ?? "unknown error"}`);
+  }
+  if (spend.ok) {
+    const rounded = formatCostUsd(spend.costUsd ?? 0);
+    lines.push(`Estimated cost: ${rounded} for a no-op turn`);
+  } else {
+    lines.push(`Estimated cost: ${spend.error ?? "unknown error"}`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Format a USD cost to a readable string. Amounts below 1 cent are shown
+ * in scientific notation so users can tell "$1e-05" apart from "$0.00".
+ */
+export function formatCostUsd(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return "$0.00";
+  if (value < 0.01) return `$${value.toExponential(2)}`;
+  if (value < 1) return `$${value.toFixed(4)}`;
+  return `$${value.toFixed(2)}`;
+}

--- a/extensions/sf-llm-gateway-internal/tests/model-group-drift.test.ts
+++ b/extensions/sf-llm-gateway-internal/tests/model-group-drift.test.ts
@@ -1,0 +1,79 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/** Unit tests for model-group provider drift detection + formatting. */
+import { describe, expect, it } from "vitest";
+import { diffModelGroupProviders, type GatewayModelGroupInfoMap } from "../lib/models.ts";
+import { formatModelGroupDriftLines } from "../lib/status.ts";
+
+describe("diffModelGroupProviders", () => {
+  it("returns an empty array for identical snapshots", () => {
+    const snap: GatewayModelGroupInfoMap = {
+      "claude-opus-4-7": { modelGroup: "claude-opus-4-7", providers: ["bedrock"] },
+      "gpt-5": { modelGroup: "gpt-5", providers: ["openai"] },
+    };
+    expect(diffModelGroupProviders(snap, snap)).toEqual([]);
+  });
+
+  it("detects providers added to an existing group", () => {
+    const prev: GatewayModelGroupInfoMap = {
+      "claude-opus-4-7": { modelGroup: "claude-opus-4-7", providers: ["bedrock"] },
+    };
+    const curr: GatewayModelGroupInfoMap = {
+      "claude-opus-4-7": {
+        modelGroup: "claude-opus-4-7",
+        providers: ["anthropic", "bedrock"],
+      },
+    };
+    const drift = diffModelGroupProviders(prev, curr);
+    expect(drift).toHaveLength(1);
+    expect(drift[0]).toMatchObject({
+      modelGroup: "claude-opus-4-7",
+      previousProviders: ["bedrock"],
+      currentProviders: ["anthropic", "bedrock"],
+    });
+  });
+
+  it("detects groups added and removed", () => {
+    const prev: GatewayModelGroupInfoMap = {
+      "gpt-5": { modelGroup: "gpt-5", providers: ["openai"] },
+    };
+    const curr: GatewayModelGroupInfoMap = {
+      "claude-opus-4-7": { modelGroup: "claude-opus-4-7", providers: ["bedrock"] },
+    };
+    const drift = diffModelGroupProviders(prev, curr);
+    expect(drift).toHaveLength(2);
+    // Sorted alphabetically by model_group.
+    expect(drift.map((d) => d.modelGroup)).toEqual(["claude-opus-4-7", "gpt-5"]);
+    expect(drift[1].currentProviders).toEqual([]);
+  });
+});
+
+describe("formatModelGroupDriftLines", () => {
+  it("returns an empty array when no drift is present", () => {
+    expect(formatModelGroupDriftLines([])).toEqual([]);
+  });
+
+  it("renders a header plus one line per drifting group", () => {
+    const lines = formatModelGroupDriftLines([
+      {
+        modelGroup: "claude-opus-4-7",
+        previousProviders: ["bedrock"],
+        currentProviders: ["anthropic", "bedrock"],
+      },
+    ]);
+    expect(lines[0]).toContain("Model-group provider drift");
+    expect(lines[1]).toContain("claude-opus-4-7");
+    expect(lines[1]).toContain("[bedrock]");
+    expect(lines[1]).toContain("[anthropic, bedrock]");
+  });
+
+  it("renders empty arrays as (none) so the line stays readable", () => {
+    const lines = formatModelGroupDriftLines([
+      {
+        modelGroup: "gone-away",
+        previousProviders: ["openai"],
+        currentProviders: [],
+      },
+    ]);
+    expect(lines[1]).toContain("(none)");
+  });
+});

--- a/extensions/sf-llm-gateway-internal/tests/monthly-usage.test.ts
+++ b/extensions/sf-llm-gateway-internal/tests/monthly-usage.test.ts
@@ -9,7 +9,11 @@ import {
   getMonthlyUsageState,
 } from "../../../lib/common/monthly-usage/store.ts";
 import { API_KEY_ENV, BASE_URL_ENV } from "../lib/config.ts";
-import { registerGatewayMonthlyUsageRefresher } from "../lib/monthly-usage.ts";
+import {
+  fetchDailyActivity,
+  fetchKeyList,
+  registerGatewayMonthlyUsageRefresher,
+} from "../lib/monthly-usage.ts";
 
 const originalFetch = globalThis.fetch;
 const originalBaseUrl = process.env[BASE_URL_ENV];
@@ -81,6 +85,165 @@ describe("gateway monthly usage refresh", () => {
       unregister();
     }
   });
+
+  it("publishes daily activity alongside the other probes", async () => {
+    process.env[BASE_URL_ENV] = "https://gateway.example.test";
+    process.env[API_KEY_ENV] = "test-key";
+    mockGatewayFetch({
+      userStatus: 200,
+      keyStatus: 200,
+      healthStatus: 200,
+      dailyStatus: 200,
+    });
+    const unregister = registerGatewayMonthlyUsageRefresher();
+    const cwd = createProjectConfig({
+      baseUrl: "https://gateway.example.test",
+      apiKey: "test-key",
+    });
+
+    try {
+      await getMonthlyUsageStateRefresh(true, cwd);
+      const snapshot = getMonthlyUsageState();
+      expect(snapshot.dailyActivityError).toBeNull();
+      expect(snapshot.dailyActivity?.entries).toHaveLength(2);
+      expect(snapshot.dailyActivity?.entries[0]).toMatchObject({
+        date: "2026-05-04",
+        spend: 1.25,
+        failedRequests: 0,
+        apiRequests: 100,
+      });
+      // Sorted ascending by date.
+      expect(snapshot.dailyActivity?.entries[1].date).toBe("2026-05-05");
+      // Connection status stays "connected" regardless of daily activity.
+      expect(snapshot.connectionStatus?.kind).toBe("connected");
+    } finally {
+      unregister();
+    }
+  });
+
+  it("publishes the key-list count alongside other probes", async () => {
+    process.env[BASE_URL_ENV] = "https://gateway.example.test";
+    process.env[API_KEY_ENV] = "test-key";
+    mockGatewayFetch({
+      userStatus: 200,
+      keyStatus: 200,
+      healthStatus: 200,
+      dailyStatus: 200,
+      keyListStatus: 200,
+    });
+    const unregister = registerGatewayMonthlyUsageRefresher();
+    const cwd = createProjectConfig({
+      baseUrl: "https://gateway.example.test",
+      apiKey: "test-key",
+    });
+
+    try {
+      await getMonthlyUsageStateRefresh(true, cwd);
+      const snapshot = getMonthlyUsageState();
+      expect(snapshot.keyList).toMatchObject({ count: 4 });
+      expect(snapshot.keyListError).toBeNull();
+    } finally {
+      unregister();
+    }
+  });
+
+  it("keeps connection-status connected when only daily activity fails", async () => {
+    process.env[BASE_URL_ENV] = "https://gateway.example.test";
+    process.env[API_KEY_ENV] = "test-key";
+    mockGatewayFetch({
+      userStatus: 200,
+      keyStatus: 200,
+      healthStatus: 200,
+      dailyStatus: 500,
+    });
+    const unregister = registerGatewayMonthlyUsageRefresher();
+    const cwd = createProjectConfig({
+      baseUrl: "https://gateway.example.test",
+      apiKey: "test-key",
+    });
+
+    try {
+      await getMonthlyUsageStateRefresh(true, cwd);
+      const snapshot = getMonthlyUsageState();
+      expect(snapshot.dailyActivity).toBeNull();
+      expect(snapshot.dailyActivityError).toMatch(/Daily activity/);
+      expect(snapshot.connectionStatus?.kind).toBe("connected");
+    } finally {
+      unregister();
+    }
+  });
+});
+
+describe("fetchKeyList", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("prefers total_count, falls back to keys.length", async () => {
+    const responses = [
+      jsonResponse(200, { keys: ["h1", "h2", "h3"], total_count: 5 }),
+      jsonResponse(200, { keys: ["h1", "h2"] }),
+      jsonResponse(200, {}),
+    ];
+    globalThis.fetch = vi.fn(async () => responses.shift()!) as typeof fetch;
+
+    expect((await fetchKeyList("https://gateway.example.test", "k")).count).toBe(5);
+    expect((await fetchKeyList("https://gateway.example.test", "k")).count).toBe(2);
+    expect((await fetchKeyList("https://gateway.example.test", "k")).count).toBe(0);
+  });
+
+  it("throws a structured error on 401", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse(401, { error: "Authentication Error" }),
+    ) as typeof fetch;
+    await expect(fetchKeyList("https://gateway.example.test", "k")).rejects.toThrow(
+      /Key list request failed/,
+    );
+  });
+});
+
+describe("fetchDailyActivity", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("clamps the days window to [1, 30] and sends start/end params", async () => {
+    const calls: string[] = [];
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      calls.push(String(input));
+      return jsonResponse(200, { results: [] });
+    }) as typeof fetch;
+
+    await fetchDailyActivity("https://gateway.example.test", "key", 7);
+    expect(calls[0]).toContain("/user/daily/activity");
+    expect(calls[0]).toMatch(/start_date=\d{4}-\d{2}-\d{2}/);
+    expect(calls[0]).toMatch(/end_date=\d{4}-\d{2}-\d{2}/);
+
+    // days < 1 clamps to 1, days > 30 clamps to 30.
+    await fetchDailyActivity("https://gateway.example.test", "key", 0);
+    await fetchDailyActivity("https://gateway.example.test", "key", 999);
+    const today = new Date().toISOString().slice(0, 10);
+    for (const call of calls.slice(1)) {
+      expect(call).toContain(`end_date=${today}`);
+    }
+  });
+
+  it("gracefully handles an empty results array", async () => {
+    globalThis.fetch = vi.fn(async () => jsonResponse(200, { results: [] })) as typeof fetch;
+    const result = await fetchDailyActivity("https://gateway.example.test", "key", 7);
+    expect(result.entries).toEqual([]);
+    expect(result.startDate).toMatch(/\d{4}-\d{2}-\d{2}/);
+    expect(result.endDate).toMatch(/\d{4}-\d{2}-\d{2}/);
+  });
+
+  it("throws a structured error on 401", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse(401, { error: { message: "Authentication Error" } }),
+    ) as typeof fetch;
+    await expect(fetchDailyActivity("https://gateway.example.test", "key", 7)).rejects.toThrow(
+      /Daily activity request failed/,
+    );
+  });
 });
 
 async function getMonthlyUsageStateRefresh(force: boolean, cwd: string): Promise<void> {
@@ -103,6 +266,8 @@ function mockGatewayFetch(options: {
   userStatus: number;
   keyStatus: number;
   healthStatus: number;
+  dailyStatus?: number;
+  keyListStatus?: number;
 }): void {
   globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
     const url = String(input);
@@ -123,6 +288,46 @@ function mockGatewayFetch(options: {
     }
     if (url.endsWith("/health/readiness")) {
       return jsonResponse(options.healthStatus, { status: "connected" });
+    }
+    if (url.endsWith("/key/list")) {
+      return jsonResponse(options.keyListStatus ?? 200, {
+        keys: ["h1", "h2", "h3", "h4"],
+        total_count: 4,
+      });
+    }
+    if (url.includes("/user/daily/activity")) {
+      return jsonResponse(options.dailyStatus ?? 200, {
+        results: [
+          {
+            date: "2026-05-05",
+            metrics: {
+              spend: 2.5,
+              prompt_tokens: 2000,
+              completion_tokens: 500,
+              cache_read_input_tokens: 1000,
+              cache_creation_input_tokens: 200,
+              total_tokens: 3700,
+              successful_requests: 200,
+              failed_requests: 0,
+              api_requests: 200,
+            },
+          },
+          {
+            date: "2026-05-04",
+            metrics: {
+              spend: 1.25,
+              prompt_tokens: 1000,
+              completion_tokens: 250,
+              cache_read_input_tokens: 500,
+              cache_creation_input_tokens: 100,
+              total_tokens: 1850,
+              successful_requests: 100,
+              failed_requests: 0,
+              api_requests: 100,
+            },
+          },
+        ],
+      });
     }
     return jsonResponse(404, { error: "not found" });
   }) as typeof fetch;

--- a/extensions/sf-llm-gateway-internal/tests/onboarding.test.ts
+++ b/extensions/sf-llm-gateway-internal/tests/onboarding.test.ts
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/** Unit tests for the SSO onboarding deep-link builder. */
+import { describe, expect, it } from "vitest";
+import { buildOnboardingUrl, OnboardingTarget } from "../lib/onboarding.ts";
+
+describe("buildOnboardingUrl", () => {
+  it("returns an empty string when base URL is missing", () => {
+    expect(buildOnboardingUrl(undefined)).toBe("");
+    expect(buildOnboardingUrl("")).toBe("");
+  });
+
+  it("strips known deployment suffixes before building the URL", () => {
+    // /v1, /bedrock, /bedrock/v1 all canonicalize to the gateway root.
+    expect(buildOnboardingUrl("https://gateway.example.com/v1")).toBe(
+      "https://gateway.example.com/oauth2/start?rd=/ui/?page=api-keys",
+    );
+    expect(buildOnboardingUrl("https://gateway.example.com/bedrock")).toBe(
+      "https://gateway.example.com/oauth2/start?rd=/ui/?page=api-keys",
+    );
+  });
+
+  it("defaults to the Virtual Keys tab", () => {
+    const url = buildOnboardingUrl("https://gateway.example.com");
+    expect(url).toContain("/oauth2/start");
+    expect(url).toContain("rd=/ui/?page=api-keys");
+  });
+
+  it("honors an explicit target", () => {
+    const url = buildOnboardingUrl("https://gateway.example.com", OnboardingTarget.ApiKeys);
+    expect(url.endsWith("api-keys")).toBe(true);
+  });
+});

--- a/extensions/sf-llm-gateway-internal/tests/status.test.ts
+++ b/extensions/sf-llm-gateway-internal/tests/status.test.ts
@@ -10,7 +10,13 @@ import { BETAS_ENV } from "../lib/config.ts";
 
 const originalHomeEnv = process.env.HOME;
 const originalAsciiIconsEnv = process.env.SF_PI_ASCII_ICONS;
-import { buildFooterStatus, buildStatusReport } from "../lib/status.ts";
+import {
+  buildFooterStatus,
+  buildStatusReport,
+  formatDailyActivityReportLine,
+  formatKeyListReportLine,
+  formatSparkline,
+} from "../lib/status.ts";
 import { KNOWN_BETAS } from "../lib/models.ts";
 
 const originalBetasEnv = process.env[BETAS_ENV];
@@ -205,5 +211,99 @@ describe("buildStatusReport", () => {
     expect(report).toContain("Custom injected betas:");
     expect(report).toContain("my-custom-beta-2099-01-01");
     expect(report).toContain("Beta source: command override");
+  });
+});
+
+describe("formatSparkline", () => {
+  it("returns an empty string for an empty series", () => {
+    expect(formatSparkline([])).toBe("");
+  });
+
+  it("renders an all-zero series as the minimum block for every day", () => {
+    expect(formatSparkline([0, 0, 0])).toBe("\u2581\u2581\u2581");
+  });
+
+  it("scales values into eight bar heights", () => {
+    const out = formatSparkline([1, 2, 4, 8]);
+    expect(out).toHaveLength(4);
+    // First entry is the smallest, last entry is the largest block.
+    expect(out[0]).toBe("\u2581");
+    expect(out[3]).toBe("\u2588");
+  });
+});
+
+describe("formatKeyListReportLine", () => {
+  const fetchedAt = new Date().toISOString();
+
+  it("falls back to the error when both args are missing", () => {
+    expect(formatKeyListReportLine(null, null)).toBe("not loaded yet");
+    expect(formatKeyListReportLine(null, "boom")).toBe("boom");
+  });
+
+  it("renders the count plus the active key name when ≤ 1 key", () => {
+    expect(formatKeyListReportLine({ count: 1, fetchedAt }, null, "sk-...abc")).toBe(
+      "1, active: sk-...abc",
+    );
+    expect(formatKeyListReportLine({ count: 0, fetchedAt }, null)).toBe("0");
+  });
+
+  it("warns when multiple keys are on file", () => {
+    const line = formatKeyListReportLine({ count: 4, fetchedAt }, null, "sk-...def");
+    expect(line).toContain("4");
+    expect(line).toContain("consider pruning");
+    expect(line).toContain("sk-...def");
+  });
+});
+
+describe("formatDailyActivityReportLine", () => {
+  it("shows not-loaded-yet when both args are null", () => {
+    expect(formatDailyActivityReportLine(null, null)).toBe("not loaded yet");
+  });
+
+  it("returns the error message when only the error is present", () => {
+    expect(formatDailyActivityReportLine(null, "boom")).toBe("boom");
+  });
+
+  it("renders totals plus a sparkline when entries are present", () => {
+    const line = formatDailyActivityReportLine(
+      {
+        entries: [
+          {
+            date: "2026-05-04",
+            spend: 1.25,
+            promptTokens: 0,
+            completionTokens: 0,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            totalTokens: 0,
+            successfulRequests: 100,
+            failedRequests: 0,
+            apiRequests: 100,
+          },
+          {
+            date: "2026-05-05",
+            spend: 2.5,
+            promptTokens: 0,
+            completionTokens: 0,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            totalTokens: 0,
+            successfulRequests: 195,
+            failedRequests: 5,
+            apiRequests: 200,
+          },
+        ],
+        startDate: "2026-05-04",
+        endDate: "2026-05-05",
+        fetchedAt: new Date().toISOString(),
+      },
+      null,
+    );
+
+    expect(line).toContain("$3.75");
+    expect(line).toContain("300 requests");
+    expect(line).toContain("(5 failed");
+    expect(line).toContain("\u26A0"); // warning glyph when failures > 0
+    expect(line).toContain("spend:");
   });
 });

--- a/extensions/sf-llm-gateway-internal/tests/token-counter.test.ts
+++ b/extensions/sf-llm-gateway-internal/tests/token-counter.test.ts
@@ -1,0 +1,188 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/** Unit tests for gateway token counting and spend estimation helpers. */
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { API_KEY_ENV, BASE_URL_ENV } from "../lib/config.ts";
+import {
+  countTokens,
+  estimateSpend,
+  formatCostUsd,
+  formatTokenReport,
+} from "../lib/token-counter.ts";
+
+const originalFetch = globalThis.fetch;
+const originalBaseUrl = process.env[BASE_URL_ENV];
+const originalApiKey = process.env[API_KEY_ENV];
+
+describe("countTokens", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    restoreEnv(BASE_URL_ENV, originalBaseUrl);
+    restoreEnv(API_KEY_ENV, originalApiKey);
+    vi.restoreAllMocks();
+  });
+
+  it("returns an error when base URL is missing", async () => {
+    delete process.env[BASE_URL_ENV];
+    delete process.env[API_KEY_ENV];
+    const cwd = createProjectConfig({ baseUrl: "", apiKey: "" });
+    const result = await countTokens(cwd, { model: "gpt-5", prompt: "hello" });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/base URL/i);
+  });
+
+  it("returns an error when neither prompt nor messages is provided", async () => {
+    const cwd = createProjectConfig({
+      baseUrl: "https://gateway.example.test",
+      apiKey: "test-key",
+    });
+    const result = await countTokens(cwd, { model: "gpt-5" });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/prompt or messages/);
+  });
+
+  it("parses a successful token_counter response", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse(200, {
+        total_tokens: 6,
+        request_model: "gpt-5",
+        model_used: "gpt-5",
+        tokenizer_type: "openai_tokenizer",
+      }),
+    ) as typeof fetch;
+    const cwd = createProjectConfig({
+      baseUrl: "https://gateway.example.test",
+      apiKey: "test-key",
+    });
+    const result = await countTokens(cwd, { model: "gpt-5", prompt: "Hello world" });
+    expect(result).toMatchObject({
+      ok: true,
+      model: "gpt-5",
+      totalTokens: 6,
+      tokenizerType: "openai_tokenizer",
+    });
+  });
+
+  it("prefers messages when both prompt and messages are provided", async () => {
+    const calls: Array<{ body: string }> = [];
+    globalThis.fetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ body: String(init?.body ?? "") });
+      return jsonResponse(200, { total_tokens: 3, tokenizer_type: "openai_tokenizer" });
+    }) as typeof fetch;
+    const cwd = createProjectConfig({
+      baseUrl: "https://gateway.example.test",
+      apiKey: "test-key",
+    });
+    await countTokens(cwd, {
+      model: "gpt-5",
+      prompt: "ignored when messages present",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    const body = JSON.parse(calls[0].body);
+    expect(body.messages).toBeDefined();
+    expect(body.prompt).toBeUndefined();
+  });
+
+  it("surfaces a structured error on 401", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse(401, { error: "Authentication Error" }),
+    ) as typeof fetch;
+    const cwd = createProjectConfig({
+      baseUrl: "https://gateway.example.test",
+      apiKey: "bad",
+    });
+    const result = await countTokens(cwd, { model: "gpt-5", prompt: "hi" });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/token_counter returned 401/);
+  });
+});
+
+describe("estimateSpend", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("parses a successful spend/calculate response", async () => {
+    globalThis.fetch = vi.fn(async () => jsonResponse(200, { cost: 0.000015 })) as typeof fetch;
+    const cwd = createProjectConfig({
+      baseUrl: "https://gateway.example.test",
+      apiKey: "test-key",
+    });
+    const result = await estimateSpend(cwd, { model: "gpt-5", prompt: "hi" });
+    expect(result).toMatchObject({ ok: true, costUsd: 0.000015 });
+  });
+
+  it("wraps a bare prompt into a synthetic user message", async () => {
+    const calls: Array<{ body: string }> = [];
+    globalThis.fetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ body: String(init?.body ?? "") });
+      return jsonResponse(200, { cost: 0 });
+    }) as typeof fetch;
+    const cwd = createProjectConfig({
+      baseUrl: "https://gateway.example.test",
+      apiKey: "test-key",
+    });
+    await estimateSpend(cwd, { model: "gpt-5", prompt: "wrap me" });
+    const body = JSON.parse(calls[0].body);
+    expect(body.messages).toEqual([{ role: "user", content: "wrap me" }]);
+  });
+});
+
+describe("formatCostUsd", () => {
+  it("renders zero and sub-cent values predictably", () => {
+    expect(formatCostUsd(0)).toBe("$0.00");
+    expect(formatCostUsd(-5)).toBe("$0.00");
+    expect(formatCostUsd(0.000015)).toBe("$1.50e-5");
+    // Sub-cent values use scientific notation so they stay distinguishable
+    // from "$0.00".
+    expect(formatCostUsd(0.005)).toBe("$5.00e-3");
+    expect(formatCostUsd(0.05)).toBe("$0.0500");
+    expect(formatCostUsd(1.25)).toBe("$1.25");
+  });
+});
+
+describe("formatTokenReport", () => {
+  it("renders a combined summary when both probes succeed", () => {
+    const text = formatTokenReport(
+      { ok: true, model: "gpt-5", totalTokens: 6, tokenizerType: "openai_tokenizer" },
+      { ok: true, model: "gpt-5", costUsd: 0.000015 },
+    );
+    expect(text).toContain("Tokens: 6 using openai_tokenizer on gpt-5");
+    expect(text).toContain("Estimated cost: $1.50e-5");
+  });
+
+  it("renders the error message when token counting fails", () => {
+    const text = formatTokenReport(
+      { ok: false, model: "gpt-5", error: "token_counter returned 401." },
+      { ok: false, model: "gpt-5", error: "spend/calculate returned 401." },
+    );
+    expect(text).toContain("Tokens: token_counter returned 401.");
+    expect(text).toContain("Estimated cost: spend/calculate returned 401.");
+  });
+});
+
+function createProjectConfig(config: { baseUrl: string; apiKey: string }): string {
+  const cwd = mkdtempSync(join(tmpdir(), "sf-pi-token-test-"));
+  const configDir = join(cwd, ".pi");
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(
+    join(configDir, "sf-llm-gateway-internal.json"),
+    `${JSON.stringify({ enabled: true, ...config })}\n`,
+  );
+  return cwd;
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}

--- a/lib/common/monthly-usage/store.ts
+++ b/lib/common/monthly-usage/store.ts
@@ -39,6 +39,17 @@ export interface GatewayKeyInfo {
   fetchedAt: string;
 }
 
+/**
+ * Lightweight result of `/key/list` — only the number of keys the user has
+ * on this gateway account. The gateway returns hashed key ids; we never
+ * store them. Non-null `count > 1` is the trigger the extension uses to
+ * warn about using a stale shell-exported key.
+ */
+export interface GatewayKeyList {
+  count: number;
+  fetchedAt: string;
+}
+
 export interface GatewayHealth {
   /** `/health/readiness.status`, e.g. `"connected"`. */
   status: string;
@@ -46,6 +57,34 @@ export interface GatewayHealth {
   litellmVersion?: string;
   /** Gateway-reported last-updated timestamp. */
   lastUpdated?: string;
+  fetchedAt: string;
+}
+
+/**
+ * One day of per-user activity metrics from `/user/daily/activity`.
+ *
+ * Unlike `/user/info` (which gives a single monthly rollup), this endpoint
+ * returns per-day granularity, including `failed_requests` which is the
+ * cleanest early-warning signal for gateway degradation.
+ */
+export interface GatewayDailyActivityEntry {
+  /** ISO date, e.g. "2026-05-05". */
+  date: string;
+  spend: number;
+  promptTokens: number;
+  completionTokens: number;
+  cacheReadInputTokens: number;
+  cacheCreationInputTokens: number;
+  totalTokens: number;
+  successfulRequests: number;
+  failedRequests: number;
+  apiRequests: number;
+}
+
+export interface GatewayDailyActivity {
+  entries: GatewayDailyActivityEntry[];
+  startDate: string;
+  endDate: string;
   fetchedAt: string;
 }
 
@@ -63,7 +102,14 @@ export interface GatewayConnectionStatus {
   kind: GatewayConnectionKind;
   detail?: string;
   checkedAt?: string;
-  source?: "user-info" | "key-info" | "models" | "health" | "config";
+  source?:
+    | "user-info"
+    | "key-info"
+    | "models"
+    | "health"
+    | "config"
+    | "daily-activity"
+    | "key-list";
 }
 
 export interface MonthlyUsageSnapshot {
@@ -74,6 +120,15 @@ export interface MonthlyUsageSnapshot {
   health: GatewayHealth | null;
   healthError: string | null;
   connectionStatus?: GatewayConnectionStatus | null;
+  /**
+   * Per-day activity for the current user. Optional so pre-Phase-1 consumers
+   * keep compiling; when absent, treat it the same as an empty snapshot.
+   */
+  dailyActivity?: GatewayDailyActivity | null;
+  dailyActivityError?: string | null;
+  /** Number of keys this user has on the gateway, from `/key/list`. */
+  keyList?: GatewayKeyList | null;
+  keyListError?: string | null;
 }
 
 export type MonthlyUsageRefresher = (force: boolean, cwd: string) => Promise<void>;
@@ -90,6 +145,10 @@ const EMPTY_SNAPSHOT: MonthlyUsageSnapshot = {
   health: null,
   healthError: null,
   connectionStatus: null,
+  dailyActivity: null,
+  dailyActivityError: null,
+  keyList: null,
+  keyListError: null,
 };
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
…oarding, drift detection

Additive observability + onboarding upgrades driven by endpoint enumeration against the live LiteLLM proxy. No transport-path changes.

Phase 1 (observability):

- `GET /user/daily/activity` fetched in parallel with the existing user-info / key-info / health probes. Snapshot includes per-day spend, token breakdown, and failed-request count (the cleanest early-warning signal for gateway degradation). Connection status is unchanged when this endpoint fails.
- Status report gains a `Last 7d` line with totals plus a sparkline.
- `/sf-llm-gateway-internal usage-probe` now renders per-day rows.
- New `/sf-llm-gateway-internal tokens <modelId> [prompt]` command wraps `/utils/token_counter` + `/spend/calculate` so users can count tokens and preview USD cost server-side with zero inference spend. Replaces any need to ship a local tokenizer.
- Doctor gains an un-authenticated `/.well-known/litellm-ui-config` signature check so misconfigured base URLs (e.g. SSO portal pasted instead of the API gateway) are called out before the first 401.
- New `pingGateway()` helper in doctor.ts uses `/test` as a minimal liveness probe — 17 bytes vs the 450-byte readiness payload.

Phase 2 (UX polish):

- `GET /key/list` added to the parallel fetch. Status surfaces the number of keys on the user's account; only hashes are read, never stored. Warns when count > 1 since teammate-exported shell vars are a common source of "why am I still on the old key" confusion.
- `GET /model_group/info` snapshotted at discovery. When the provider list of a model group changes between discoveries (e.g. admin adds a second cloud provider behind a group), the drift is surfaced as a warning line in the status report. Detection only; no routing change.
- New `/sf-llm-gateway-internal onboard` command prints a one-click SSO URL that lands the user directly on the LiteLLM admin UI's Virtual Keys tab (`/oauth2/start?rd=/ui/?page=api-keys`). The `rd=` param was the only post-login-destination override that works on this LiteLLM build; `next=` and `redirect=` are ignored.

Tests: 46 new unit tests across 5 files, all green. No transport.ts changes; gpt-5.5 Responses-API pivot lands separately.

## What this PR does

<!-- One or two lines. What changes, and for which extension/area? -->

## Why

<!-- The user-facing problem this solves. Link the issue if there is one. -->

Closes #

## How

<!-- Bullet the key changes. Mention any non-obvious design decisions. -->

-
-

## Checklist

- [ ] I ran `npm run validate` locally
- [ ] I updated the affected extension's `README.md` (if behavior changed)
- [ ] I added or updated tests
- [ ] I regenerated the catalog (`npm run generate-catalog`) if I touched `manifest.json`
- [ ] I added a `CHANGELOG.md` entry under `[Unreleased]`
- [ ] This PR is non-breaking, or I called out the breaking change explicitly above

## Notes for reviewers

<!-- Anything to watch out for — gotchas, follow-up work, screenshots. -->
