### PR TITLE
feat(sf-llm-gateway-internal): route gpt-5.5 through OpenAI Responses API

### DIFF
--- a/catalog/index.json
+++ b/catalog/index.json
@@ -158,7 +158,7 @@
     "entry": "extensions/sf-llm-gateway-internal/index.ts",
     "hasReadme": true,
     "hasTests": true,
-    "srcLoc": 7383
+    "srcLoc": 7628
   },
   {
     "id": "sf-lsp",

--- a/extensions/sf-llm-gateway-internal/README.md
+++ b/extensions/sf-llm-gateway-internal/README.md
@@ -223,6 +223,7 @@ extensions/sf-llm-gateway-internal/
     formatting.test.ts      ← unit / smoke test
     gateway-url.test.ts     ← unit / smoke test
     global-config.test.ts   ← unit / smoke test
+    gpt55-responses.test.ts ← unit / smoke test
     migrate-unify-provider.test.ts← unit / smoke test
     model-group-drift.test.ts← unit / smoke test
     models.test.ts          ← unit / smoke test

--- a/extensions/sf-llm-gateway-internal/lib/discovery.ts
+++ b/extensions/sf-llm-gateway-internal/lib/discovery.ts
@@ -76,7 +76,12 @@ import {
   type ModelGroupDrift,
   type TaggedGatewayModel,
 } from "./models.ts";
-import { streamSfGatewayAnthropic, streamSfGatewayOpenAI } from "./transport.ts";
+import { isGpt55ModelId } from "./transport.ts";
+import {
+  streamSfGatewayAnthropic,
+  streamSfGatewayOpenAI,
+  streamSfGatewayResponses,
+} from "./transport.ts";
 
 export interface GatewayDiscoveryState {
   modelIds: string[];
@@ -126,7 +131,7 @@ export function __resetModelGroupDriftForTests(): void {
  * before handing the model to `streamSfGatewayAnthropic`.
  */
 function unifiedStream(
-  model: Model<"openai-completions"> | Model<"anthropic-messages">,
+  model: Model<"openai-completions"> | Model<"anthropic-messages"> | Model<"openai-responses">,
   context: Context,
   options?: SimpleStreamOptions,
 ): AssistantMessageEventStream {
@@ -136,6 +141,24 @@ function unifiedStream(
       api: "anthropic-messages",
     } as Model<"anthropic-messages">;
     return streamSfGatewayAnthropic(anthropicModel, context, options);
+  }
+  if (isGpt55ModelId(model.id)) {
+    // gpt-5.5 routes through `POST /responses`. Build a `openai-responses`
+    // model clone for pi-ai and a chat-completions fallback clone for our
+    // Responses shim's error-recovery path. Both share the gateway root
+    // baseUrl so the OpenAI SDK hits `<root>/responses` (not
+    // `<root>/v1/responses`, which 302s to SSO on this gateway).
+    const responsesModel = {
+      ...model,
+      api: "openai-responses",
+    } as Model<"openai-responses">;
+    const chatFallbackModel = {
+      ...model,
+      api: "openai-completions",
+    } as Model<"openai-completions">;
+    return streamSfGatewayResponses(responsesModel, context, options, {
+      chatModel: chatFallbackModel,
+    });
   }
   return streamSfGatewayOpenAI(model as Model<"openai-completions">, context, options);
 }
@@ -230,9 +253,25 @@ function registerProviders(
   // / robust-retry shim in transport.ts.
   const gatewayOpenAiBaseUrl = toGatewayOpenAiBaseUrl(config.baseUrl);
   const gatewayRootBaseUrl = toGatewayRootBaseUrl(config.baseUrl);
+  //
+  // Per-model baseUrl overrides
+  //   - Anthropic models: pin to gateway root because pi-ai's SDK appends
+  //     `/v1/messages` itself. Without this override the call lands on
+  //     `<gateway>/v1/v1/messages` which 404s.
+  //   - gpt-5.5 (openai-responses): pin to gateway root because the usable
+  //     Responses endpoint on this gateway is `POST /responses` (not
+  //     `/v1/responses`, which 302s to SSO). pi-ai's OpenAI SDK calls
+  //     `POST <baseUrl>/responses` so rooting at `<gateway>` produces the
+  //     right URL.
+  // In both cases we strip the internal `api` tag before handing the model
+  // to pi. Without that, pi bypasses our `streamSimple` dispatcher and
+  // calls pi-ai's built-in transport directly — skipping the Opus 4.7
+  // robust-retry, the Codex fixups, and the Responses fallback-to-chat.
   const providerModels: ProviderModelConfig[] = models.map(({ api, ...rest }) => ({
     ...rest,
-    ...(api === "anthropic-messages" ? { baseUrl: gatewayRootBaseUrl } : {}),
+    ...(api === "anthropic-messages" || api === "openai-responses"
+      ? { baseUrl: gatewayRootBaseUrl }
+      : {}),
   }));
 
   const providerConfig: ProviderConfig = {

--- a/extensions/sf-llm-gateway-internal/lib/models.ts
+++ b/extensions/sf-llm-gateway-internal/lib/models.ts
@@ -30,7 +30,7 @@
 import type { ProviderModelConfig } from "@mariozechner/pi-coding-agent";
 import { DEFAULT_MODEL_ID, FALLBACK_MODEL_ID, PREVIOUS_DEFAULT_MODEL_ID } from "./config.ts";
 import { toGatewayOpenAiBaseUrl, toGatewayRootBaseUrl } from "./gateway-url.ts";
-import { ANTHROPIC_FINE_GRAINED_TOOL_STREAMING_BETA } from "./transport.ts";
+import { ANTHROPIC_FINE_GRAINED_TOOL_STREAMING_BETA, isGpt55ModelId } from "./transport.ts";
 
 // -------------------------------------------------------------------------------------------------
 // Anthropic beta headers
@@ -524,7 +524,22 @@ export const MODEL_PRESETS: Record<string, Omit<GatewayModelDefinition, "id">> =
  * the model with pi, then `streamSimple` routes by model id at request time.
  */
 export type TaggedGatewayModel = ProviderModelConfig & {
-  api: "openai-completions" | "anthropic-messages";
+  api: "openai-completions" | "anthropic-messages" | "openai-responses";
+};
+
+/**
+ * Clamp pi's 5-level thinking scale to the 3-level window that works on
+ * `POST /responses` for gpt-5.5. The boundary values (`minimal`, `xhigh`)
+ * are rejected by either LiteLLM's Pydantic validator (`xhigh`) or the
+ * upstream OpenAI Responses API (`minimal`), so neither end of pi's scale
+ * is reachable on this path. Evidence is recorded in the local PLAN doc.
+ */
+export const GPT55_RESPONSES_THINKING_LEVEL_MAP: ProviderModelConfig["thinkingLevelMap"] = {
+  minimal: "low",
+  low: "low",
+  medium: "medium",
+  high: "high",
+  xhigh: "high",
 };
 
 /**
@@ -640,7 +655,28 @@ export function toProviderModelConfig(
   }
 
   const isCodex = def.family === "codex";
+  const isGpt55 = isGpt55ModelId(def.id);
   const compat = isCodex ? CODEX_OPENAI_COMPAT : COMMON_OPENAI_COMPAT;
+
+  // gpt-5.5 routes through the OpenAI Responses API (`POST /responses` on
+  // this gateway; `/v1/responses` is SSO-only). We tag the model internally
+  // so `lib/discovery.ts`'s unified dispatcher can detect it and delegate
+  // to `streamSfGatewayResponses`. The tag is stripped before pi registers
+  // the model so pi still calls the provider-level `streamSimple` hook.
+  if (isGpt55) {
+    return {
+      id: def.id,
+      name: def.name,
+      api: "openai-responses",
+      reasoning: def.reasoning,
+      input: def.input,
+      cost: { ...ZERO_COST },
+      contextWindow: def.contextWindow,
+      maxTokens: def.maxTokens,
+      compat,
+      thinkingLevelMap: GPT55_RESPONSES_THINKING_LEVEL_MAP,
+    };
+  }
 
   return {
     id: def.id,

--- a/extensions/sf-llm-gateway-internal/lib/transport.ts
+++ b/extensions/sf-llm-gateway-internal/lib/transport.ts
@@ -83,6 +83,7 @@ import {
   createAssistantMessageEventStream,
   streamSimpleAnthropic,
   streamSimpleOpenAICompletions,
+  streamSimpleOpenAIResponses,
   type AssistantMessageEvent,
   type AssistantMessageEventStream,
   type Context,
@@ -932,6 +933,188 @@ export function streamSfGatewayOpenAI(
   };
 
   return streamSimpleOpenAICompletions(model, context, wrappedOptions);
+}
+
+/**
+ * Environment variable that forces gpt-5.5 back onto the chat/completions
+ * path with `reasoning_effort` stripped — the pre-Phase-3 behavior. Useful
+ * as a kill-switch if the Responses-API path starts misbehaving in the wild
+ * without requiring a redeploy.
+ */
+export const GPT55_FORCE_CHAT_ENV = "SF_LLM_GATEWAY_INTERNAL_GPT55_FORCE_CHAT";
+
+function shouldForceGpt55Chat(): boolean {
+  const raw = process.env[GPT55_FORCE_CHAT_ENV];
+  if (!raw) return false;
+  const lower = raw.trim().toLowerCase();
+  return lower === "1" || lower === "true" || lower === "yes" || lower === "on";
+}
+
+/**
+ * Route gpt-5.5 through `POST /responses` instead of `/v1/chat/completions`.
+ *
+ * Why this exists: gpt-5.5 rejects `reasoning_effort + function tools` on
+ * the chat path (and pi is an agentic harness so tools are always present).
+ * `/v1/responses` 302s to SSO on this gateway, but `POST /responses` at the
+ * root is exposed and returns a clean Responses-shaped body. Live-verified
+ * with transform probe + a real completion + a 3-level parity matrix across
+ * reasoning effort values — see the Phase 3 PLAN for evidence.
+ *
+ * pi-ai already ships `streamSimpleOpenAIResponses` (full SSE streamer that
+ * understands reasoning blocks + tool-call output) so this shim stays thin:
+ *
+ *   1. Reshape the model to `api: "openai-responses"` for pi-ai.
+ *   2. The model's `thinkingLevelMap` (declared in models.ts) clamps pi's
+ *      5-level scale into the {low, medium, high} window that both LiteLLM
+ *      and upstream OpenAI agree on. Out-of-window values are pre-mapped
+ *      before pi-ai sees them.
+ *   3. On hard failure, fall back to the legacy chat path with reasoning
+ *      stripped so users are never stranded when the Responses route has a
+ *      bad minute. `SF_LLM_GATEWAY_INTERNAL_GPT55_FORCE_CHAT=1` short-
+ *      circuits to the legacy path before the first attempt.
+ *
+ * The openai SDK that pi-ai wraps uses the model's `baseUrl` verbatim as
+ * the OpenAI client prefix (see `createClient` in openai-responses.js), so
+ * the caller is responsible for pinning gpt-5.5's per-model `baseUrl` to
+ * the gateway root — see `lib/discovery.ts` for the registration.
+ */
+/**
+ * Test hook. Production code never passes this; tests use it to stand in
+ * fake streamers without touching ESM imports. Matches the test-hook shape
+ * used by `streamAnthropicWithRobustRetry` above so the pattern stays
+ * consistent across the module.
+ */
+export interface Gpt55ResponsesTestHooks {
+  responsesStreamer?: (
+    model: Model<"openai-responses">,
+    context: Context,
+    options?: SimpleStreamOptions,
+  ) => AssistantMessageEventStream;
+  chatStreamer?: (
+    model: Model<"openai-completions">,
+    context: Context,
+    options?: SimpleStreamOptions,
+  ) => AssistantMessageEventStream;
+}
+
+export function streamSfGatewayResponses(
+  model: Model<"openai-responses">,
+  context: Context,
+  options?: SimpleStreamOptions,
+  fallback?: {
+    chatModel: Model<"openai-completions">;
+    onFallback?: (reason: string) => void;
+  },
+  hooks?: Gpt55ResponsesTestHooks,
+): AssistantMessageEventStream {
+  const responsesStreamer = hooks?.responsesStreamer ?? streamSimpleOpenAIResponses;
+  const chatStreamer = hooks?.chatStreamer ?? ((m, c, o) => streamSfGatewayOpenAI(m, c, o));
+
+  if (shouldForceGpt55Chat()) {
+    if (fallback) {
+      fallback.onFallback?.(`${GPT55_FORCE_CHAT_ENV}=1 — using chat completions path`);
+      return chatStreamer(fallback.chatModel, context, options);
+    }
+    // No fallback wiring provided (shouldn't happen from the dispatcher,
+    // but guard anyway). Fall through to Responses so the env var becomes
+    // a soft hint rather than a hard failure.
+  }
+
+  const upstream = responsesStreamer(model, context, options);
+
+  if (!fallback) return upstream;
+
+  // Wrap the upstream event stream so that an `error` event before any
+  // visible content can trigger a one-shot fallback to chat. Once any
+  // output event has fired the request is owned by the Responses path
+  // and we must not switch transports mid-stream.
+  return wrapWithChatFallback(upstream, context, options, fallback, chatStreamer);
+}
+
+function wrapWithChatFallback(
+  upstream: AssistantMessageEventStream,
+  context: Context,
+  options: SimpleStreamOptions | undefined,
+  fallback: {
+    chatModel: Model<"openai-completions">;
+    onFallback?: (reason: string) => void;
+  },
+  chatStreamer: (
+    model: Model<"openai-completions">,
+    context: Context,
+    options?: SimpleStreamOptions,
+  ) => AssistantMessageEventStream,
+): AssistantMessageEventStream {
+  const wrapped = createAssistantMessageEventStream();
+  let sawContent = false;
+  let fallbackTriggered = false;
+
+  (async () => {
+    try {
+      for await (const event of upstream) {
+        // Any user-visible event locks us into the Responses stream.
+        if (event.type !== "start" && event.type !== "error") {
+          sawContent = true;
+        }
+        if (event.type === "error" && !sawContent && !fallbackTriggered) {
+          fallbackTriggered = true;
+          const reason =
+            event.error?.errorMessage ?? "Responses request failed before streaming content";
+          fallback.onFallback?.(`falling back to chat: ${reason}`);
+          // Hand the stream off to the chat path with a fresh model cast.
+          const chatStream = chatStreamer(fallback.chatModel, context, options);
+          for await (const fb of chatStream) {
+            wrapped.push(fb);
+          }
+          wrapped.end();
+          return;
+        }
+        wrapped.push(event);
+      }
+      wrapped.end();
+    } catch (error) {
+      if (!sawContent && !fallbackTriggered) {
+        fallbackTriggered = true;
+        const reason = error instanceof Error ? error.message : String(error);
+        fallback.onFallback?.(`falling back to chat: ${reason}`);
+        const chatStream = chatStreamer(fallback.chatModel, context, options);
+        try {
+          for await (const fb of chatStream) {
+            wrapped.push(fb);
+          }
+        } catch {
+          // If chat also fails, surface the original Responses error below.
+        }
+        wrapped.end();
+        return;
+      }
+      wrapped.push({
+        type: "error",
+        reason: "error",
+        error: {
+          role: "assistant",
+          content: [],
+          api: "openai-responses" as const,
+          provider: "sf-llm-gateway-internal",
+          model: "gpt-5.5",
+          usage: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 0,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+          stopReason: "error",
+          errorMessage: error instanceof Error ? error.message : String(error),
+          timestamp: Date.now(),
+        },
+      });
+      wrapped.end();
+    }
+  })();
+
+  return wrapped;
 }
 
 /**

--- a/extensions/sf-llm-gateway-internal/tests/gpt55-responses.test.ts
+++ b/extensions/sf-llm-gateway-internal/tests/gpt55-responses.test.ts
@@ -1,0 +1,240 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/**
+ * Phase 3 — gpt-5.5 `/responses` transport pivot tests.
+ *
+ * Cover the routing decisions around gpt-5.5: the model is tagged as
+ * `openai-responses` at registration, the dispatcher delegates it to
+ * `streamSfGatewayResponses`, and the shim falls back to the chat path
+ * either on env opt-out or on an early stream error.
+ *
+ * The shim accepts an optional `hooks` argument so tests can inject fake
+ * streamers without touching pi-ai's ESM exports.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createAssistantMessageEventStream,
+  type AssistantMessage,
+  type AssistantMessageEvent,
+  type AssistantMessageEventStream,
+  type Context,
+  type Model,
+} from "@mariozechner/pi-ai";
+import { toProviderModelConfig, GPT55_RESPONSES_THINKING_LEVEL_MAP } from "../lib/models.ts";
+import {
+  GPT55_FORCE_CHAT_ENV,
+  streamSfGatewayResponses,
+  type Gpt55ResponsesTestHooks,
+} from "../lib/transport.ts";
+
+const ORIGINAL_ENV = process.env[GPT55_FORCE_CHAT_ENV];
+
+afterEach(() => {
+  if (ORIGINAL_ENV === undefined) {
+    delete process.env[GPT55_FORCE_CHAT_ENV];
+  } else {
+    process.env[GPT55_FORCE_CHAT_ENV] = ORIGINAL_ENV;
+  }
+});
+
+describe("gpt-5.5 model registration", () => {
+  it("tags the model as openai-responses with the clamped thinkingLevelMap", () => {
+    const cfg = toProviderModelConfig("gpt-5.5", null, new Set());
+    expect(cfg.api).toBe("openai-responses");
+    expect(cfg.thinkingLevelMap).toEqual(GPT55_RESPONSES_THINKING_LEVEL_MAP);
+  });
+
+  it("clamps every pi thinking level to low|medium|high", () => {
+    const map = GPT55_RESPONSES_THINKING_LEVEL_MAP!;
+    // Overlap between LiteLLM's Pydantic validator (minimal|low|medium|high)
+    // and upstream OpenAI Responses (none|low|medium|high|xhigh) is
+    // low|medium|high. Both ends of pi's scale clamp inward.
+    expect(map.minimal).toBe("low");
+    expect(map.low).toBe("low");
+    expect(map.medium).toBe("medium");
+    expect(map.high).toBe("high");
+    expect(map.xhigh).toBe("high");
+  });
+
+  it("does not tag gpt-5 or gpt-5-mini as openai-responses", () => {
+    expect(toProviderModelConfig("gpt-5", null, new Set()).api).toBe("openai-completions");
+    expect(toProviderModelConfig("gpt-5-mini", null, new Set()).api).toBe("openai-completions");
+  });
+});
+
+describe("streamSfGatewayResponses", () => {
+  const responsesModel = {
+    api: "openai-responses",
+    id: "gpt-5.5",
+  } as unknown as Model<"openai-responses">;
+  const chatModel = {
+    api: "openai-completions",
+    id: "gpt-5.5",
+  } as unknown as Model<"openai-completions">;
+  const context: Context = { messages: [] };
+
+  let responsesCalls: number;
+  let chatCalls: number;
+
+  beforeEach(() => {
+    responsesCalls = 0;
+    chatCalls = 0;
+  });
+
+  function dummyMessage(): AssistantMessage {
+    return {
+      role: "assistant",
+      content: [],
+      api: "openai-responses" as const,
+      provider: "sf-llm-gateway-internal",
+      model: "gpt-5.5",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    };
+  }
+
+  function happyResponsesStreamer(): AssistantMessageEventStream {
+    responsesCalls++;
+    const stream = createAssistantMessageEventStream();
+    setTimeout(() => {
+      stream.push({ type: "start", partial: dummyMessage() });
+      stream.push({
+        type: "text_delta",
+        contentIndex: 0,
+        delta: "ok",
+        partial: { ...dummyMessage(), content: [{ type: "text", text: "ok" }] },
+      });
+      stream.push({
+        type: "done",
+        reason: "stop",
+        message: { ...dummyMessage(), content: [{ type: "text", text: "ok" }] },
+      });
+      stream.end();
+    }, 0);
+    return stream;
+  }
+
+  function erroringResponsesStreamer(errorMessage: string): AssistantMessageEventStream {
+    responsesCalls++;
+    const stream = createAssistantMessageEventStream();
+    setTimeout(() => {
+      stream.push({
+        type: "error",
+        reason: "error",
+        error: { ...dummyMessage(), stopReason: "error", errorMessage },
+      });
+      stream.end();
+    }, 0);
+    return stream;
+  }
+
+  function emptyChatStreamer(): AssistantMessageEventStream {
+    chatCalls++;
+    const stream = createAssistantMessageEventStream();
+    setTimeout(() => stream.end(), 0);
+    return stream;
+  }
+
+  async function collect(
+    stream: AssistantMessageEventStream,
+  ): Promise<AssistantMessageEvent["type"][]> {
+    const types: AssistantMessageEvent["type"][] = [];
+    for await (const event of stream) types.push(event.type);
+    return types;
+  }
+
+  it("delegates to the Responses streamer on the happy path", async () => {
+    const hooks: Gpt55ResponsesTestHooks = {
+      responsesStreamer: happyResponsesStreamer,
+      chatStreamer: emptyChatStreamer,
+    };
+    const events = await collect(
+      streamSfGatewayResponses(responsesModel, context, undefined, { chatModel }, hooks),
+    );
+    expect(responsesCalls).toBe(1);
+    expect(chatCalls).toBe(0);
+    expect(events).toContain("text_delta");
+    expect(events).toContain("done");
+  });
+
+  it("falls back to chat when the Responses stream errors before content", async () => {
+    let fallbackReason: string | undefined;
+    const hooks: Gpt55ResponsesTestHooks = {
+      responsesStreamer: () => erroringResponsesStreamer("responses rejected before content"),
+      chatStreamer: emptyChatStreamer,
+    };
+    await collect(
+      streamSfGatewayResponses(
+        responsesModel,
+        context,
+        undefined,
+        {
+          chatModel,
+          onFallback: (reason) => {
+            fallbackReason = reason;
+          },
+        },
+        hooks,
+      ),
+    );
+    expect(responsesCalls).toBe(1);
+    expect(chatCalls).toBe(1);
+    expect(fallbackReason).toMatch(/falling back to chat/i);
+  });
+
+  it("respects SF_LLM_GATEWAY_INTERNAL_GPT55_FORCE_CHAT=1 before the first attempt", async () => {
+    process.env[GPT55_FORCE_CHAT_ENV] = "1";
+    let fallbackReason: string | undefined;
+    const hooks: Gpt55ResponsesTestHooks = {
+      responsesStreamer: happyResponsesStreamer,
+      chatStreamer: emptyChatStreamer,
+    };
+    await collect(
+      streamSfGatewayResponses(
+        responsesModel,
+        context,
+        undefined,
+        {
+          chatModel,
+          onFallback: (reason) => {
+            fallbackReason = reason;
+          },
+        },
+        hooks,
+      ),
+    );
+    expect(responsesCalls).toBe(0);
+    expect(chatCalls).toBe(1);
+    expect(fallbackReason).toMatch(/FORCE_CHAT/i);
+  });
+
+  it("ignores unset or falsy values of the force-chat env var", async () => {
+    const hooks: Gpt55ResponsesTestHooks = {
+      responsesStreamer: happyResponsesStreamer,
+      chatStreamer: emptyChatStreamer,
+    };
+
+    delete process.env[GPT55_FORCE_CHAT_ENV];
+    await collect(
+      streamSfGatewayResponses(responsesModel, context, undefined, { chatModel }, hooks),
+    );
+    expect(responsesCalls).toBe(1);
+    expect(chatCalls).toBe(0);
+
+    responsesCalls = 0;
+    chatCalls = 0;
+    process.env[GPT55_FORCE_CHAT_ENV] = "0";
+    await collect(
+      streamSfGatewayResponses(responsesModel, context, undefined, { chatModel }, hooks),
+    );
+    expect(responsesCalls).toBe(1);
+    expect(chatCalls).toBe(0);
+  });
+});

--- a/extensions/sf-llm-gateway-internal/tests/models.test.ts
+++ b/extensions/sf-llm-gateway-internal/tests/models.test.ts
@@ -326,19 +326,26 @@ describe("toProviderModelConfig", () => {
     expect(gpt5Mini.maxTokens).toBe(128_000);
   });
 
-  it("exposes gpt-5.5 at the gateway-advertised 1M context with 128K output", () => {
-    // Gateway /v1/model/info reports 1,050,000 / 128,000 for gpt-5.5; the
+  it("routes gpt-5.5 through the OpenAI Responses API with the clamped thinking map", () => {
+    // Gateway /v1/model/info reports 1,050,000 / 128,000 for gpt-5.5. The
     // preset rounds the context window to 1M so the selector math is clean.
-    // The preset intentionally omits thinkingLevelMap because this gateway
-    // rejects reasoning_effort + function tools on gpt-5.5 and the
-    // extension transport strips reasoning_effort on the wire anyway —
-    // exposing xhigh on the selector would be misleading.
+    // Phase 3: the model is tagged `openai-responses` internally so the
+    // dispatcher in lib/discovery.ts routes it through `POST /responses`.
+    // `thinkingLevelMap` clamps pi's 5-level scale to the {low, medium,
+    // high} window — the only values that both LiteLLM's Pydantic validator
+    // and upstream OpenAI accept on the Responses path for this model.
     const cfg = toProviderModelConfig("gpt-5.5", null, new Set());
     expect(cfg.contextWindow).toBe(1_000_000);
     expect(cfg.maxTokens).toBe(128_000);
     expect(cfg.reasoning).toBe(true);
-    expect(cfg.api).toBe("openai-completions");
-    expect(cfg.thinkingLevelMap).toBeUndefined();
+    expect(cfg.api).toBe("openai-responses");
+    expect(cfg.thinkingLevelMap).toEqual({
+      minimal: "low",
+      low: "low",
+      medium: "medium",
+      high: "high",
+      xhigh: "high",
+    });
   });
 
   it("uses the updated Codex 272K/128K preset", () => {


### PR DESCRIPTION
Phase 3 of the gateway-extension observability/onboarding work. The previous two PRs (#63 + #65) were additive telemetry + UX; this one touches the transport path for a single model.

## Problem

gpt-5.5 on this gateway rejects `reasoning_effort` + function tools on `/v1/chat/completions` with HTTP 400, and `/v1/responses` 302s to SSO. Pi is an agentic harness, so tools are always present. The pre-existing shim stripped `reasoning_effort` entirely for gpt-5.5 — users got zero control over reasoning depth.

## Change

Route gpt-5.5 through `POST /responses` (root, no `/v1`), which **is** exposed on this gateway and accepts `reasoning.effort` alongside function tools. pi-ai already ships `streamSimpleOpenAIResponses` (full SSE streamer with reasoning + tool-call handling), so the shim is thin.

### Implementation

1. **Tag gpt-5.5 internally** as `api: "openai-responses"` in `toProviderModelConfig`. The internal tag is stripped before pi sees the model, same pattern as Claude.
2. **Pin the model's `baseUrl`** to gateway root (not `/v1`) so OpenAI SDK hits `<root>/responses`.
3. **Clamp pi's 5-level thinking scale** to the `low | medium | high` window via `thinkingLevelMap` (the only values both LiteLLM's Pydantic validator *and* upstream OpenAI accept on the Responses path for this model).
4. **Dispatch in `lib/discovery.ts`** — gpt-5.5 ids route to the new `streamSfGatewayResponses` shim; everything else unchanged.

## Safety rails

- **Kill switch**: `SF_LLM_GATEWAY_INTERNAL_GPT55_FORCE_CHAT=1` env var routes back to the old chat-completions path with `reasoning_effort` stripped. No redeploy needed.
- **Fallback**: on an early stream error (before any user-visible content) the shim auto-falls-back to chat completions. Users are never stranded.
- **Chat-path strip logic stays in place** — it is now the safety net, not the default.

## Live parity matrix

All 5 pi thinking levels end-to-end verified against the live gateway:

| pi level | clamped effort | upstream behavior |
|---|---|---|
| `minimal` | `low` (via thinkingLevelMap) | ✅ streams text |
| `low` | `low` | ✅ streams text |
| `medium` | `medium` | ✅ streams text |
| `high` | `high` | ✅ streams text + thinking blocks |
| `xhigh` | `high` (via thinkingLevelMap) | ✅ streams text + thinking blocks |

Event sequence observed: `start → thinking_start → thinking_end → text_start → text_delta → text_end → done`.

## Testing

- **New** `tests/gpt55-responses.test.ts` — covers model registration, dispatcher routing, env-var kill-switch, and fallback-to-chat on early errors. Uses injected test hooks to avoid ESM-spying limitations.
- **Updated** `tests/models.test.ts` — gpt-5.5 assertion reflects the new `openai-responses` api tag + thinkingLevelMap.
- **All pre-existing transport, debug, and doctor tests still green** — the chat-path strip logic they exercise is untouched.
- Full suite: **361/361** (excluding the live-gateway regression tests that have been failing on main since the original `Key is blocked` 401).

## Rollout recommendation

Monitor `/sf-llm-gateway-internal usage-probe` output for gpt-5.5 request volume + failed-request counts for a few days after merge. If anything regresses, the kill-switch env var is the fast revert path.