### PR TITLE
feat(sf-llm-gateway-internal): route gpt-5 and gpt-5-mini through /responses

### DIFF
--- a/catalog/index.json
+++ b/catalog/index.json
@@ -158,7 +158,7 @@
     "entry": "extensions/sf-llm-gateway-internal/index.ts",
     "hasReadme": true,
     "hasTests": true,
-    "srcLoc": 7628
+    "srcLoc": 7684
   },
   {
     "id": "sf-lsp",

--- a/extensions/sf-llm-gateway-internal/lib/discovery.ts
+++ b/extensions/sf-llm-gateway-internal/lib/discovery.ts
@@ -76,7 +76,7 @@ import {
   type ModelGroupDrift,
   type TaggedGatewayModel,
 } from "./models.ts";
-import { isGpt55ModelId } from "./transport.ts";
+import { isGpt5FamilyResponsesModelId } from "./transport.ts";
 import {
   streamSfGatewayAnthropic,
   streamSfGatewayOpenAI,
@@ -142,12 +142,13 @@ function unifiedStream(
     } as Model<"anthropic-messages">;
     return streamSfGatewayAnthropic(anthropicModel, context, options);
   }
-  if (isGpt55ModelId(model.id)) {
-    // gpt-5.5 routes through `POST /responses`. Build a `openai-responses`
-    // model clone for pi-ai and a chat-completions fallback clone for our
-    // Responses shim's error-recovery path. Both share the gateway root
-    // baseUrl so the OpenAI SDK hits `<root>/responses` (not
-    // `<root>/v1/responses`, which 302s to SSO on this gateway).
+  if (isGpt5FamilyResponsesModelId(model.id)) {
+    // gpt-5, gpt-5-mini, gpt-5.5 route through `POST /responses`. Build a
+    // `openai-responses` model clone for pi-ai and a chat-completions
+    // fallback clone for our Responses shim's error-recovery path. Both
+    // share the gateway root baseUrl so the OpenAI SDK hits
+    // `<root>/responses` (not `<root>/v1/responses`, which 302s to SSO on
+    // this gateway).
     const responsesModel = {
       ...model,
       api: "openai-responses",

--- a/extensions/sf-llm-gateway-internal/lib/models.ts
+++ b/extensions/sf-llm-gateway-internal/lib/models.ts
@@ -30,7 +30,11 @@
 import type { ProviderModelConfig } from "@mariozechner/pi-coding-agent";
 import { DEFAULT_MODEL_ID, FALLBACK_MODEL_ID, PREVIOUS_DEFAULT_MODEL_ID } from "./config.ts";
 import { toGatewayOpenAiBaseUrl, toGatewayRootBaseUrl } from "./gateway-url.ts";
-import { ANTHROPIC_FINE_GRAINED_TOOL_STREAMING_BETA, isGpt55ModelId } from "./transport.ts";
+import {
+  ANTHROPIC_FINE_GRAINED_TOOL_STREAMING_BETA,
+  isGpt5FamilyResponsesModelId,
+  isGpt55ModelId,
+} from "./transport.ts";
 
 // -------------------------------------------------------------------------------------------------
 // Anthropic beta headers
@@ -543,6 +547,21 @@ export const GPT55_RESPONSES_THINKING_LEVEL_MAP: ProviderModelConfig["thinkingLe
 };
 
 /**
+ * Clamp pi's 5-level thinking scale for gpt-5 / gpt-5-mini on the Responses
+ * API. Upstream OpenAI supports `minimal | low | medium | high` here but
+ * rejects `xhigh` (verified live) — so pi's `xhigh` must clamp to `high`.
+ * `minimal` passes straight through, unlike gpt-5.5 which requires clamping
+ * up because its LiteLLM / upstream windows do not overlap on `minimal`.
+ */
+export const GPT5_RESPONSES_THINKING_LEVEL_MAP: ProviderModelConfig["thinkingLevelMap"] = {
+  minimal: "minimal",
+  low: "low",
+  medium: "medium",
+  high: "high",
+  xhigh: "high",
+};
+
+/**
  * Build the startup bootstrap catalog only.
  *
  * These IDs are local fallback presets so Pi can resolve gateway defaults
@@ -656,14 +675,19 @@ export function toProviderModelConfig(
 
   const isCodex = def.family === "codex";
   const isGpt55 = isGpt55ModelId(def.id);
+  const isGpt5Family = isGpt5FamilyResponsesModelId(def.id);
   const compat = isCodex ? CODEX_OPENAI_COMPAT : COMMON_OPENAI_COMPAT;
 
-  // gpt-5.5 routes through the OpenAI Responses API (`POST /responses` on
-  // this gateway; `/v1/responses` is SSO-only). We tag the model internally
-  // so `lib/discovery.ts`'s unified dispatcher can detect it and delegate
-  // to `streamSfGatewayResponses`. The tag is stripped before pi registers
-  // the model so pi still calls the provider-level `streamSimple` hook.
-  if (isGpt55) {
+  // gpt-5, gpt-5-mini, gpt-5.5 all route through the OpenAI Responses API
+  // (`POST /responses` on this gateway; `/v1/responses` is SSO-only). The
+  // working reasoning.effort window is model-specific:
+  //   - gpt-5 / gpt-5-mini: minimal | low | medium | high  (xhigh → high)
+  //   - gpt-5.5:            low | medium | high            (minimal → low,
+  //                                                        xhigh  → high)
+  // The internal api tag is stripped before pi registers the model so pi
+  // still calls the provider-level `streamSimple` hook; the dispatcher
+  // reads the id to pick the right shim.
+  if (isGpt5Family) {
     return {
       id: def.id,
       name: def.name,
@@ -674,7 +698,9 @@ export function toProviderModelConfig(
       contextWindow: def.contextWindow,
       maxTokens: def.maxTokens,
       compat,
-      thinkingLevelMap: GPT55_RESPONSES_THINKING_LEVEL_MAP,
+      thinkingLevelMap: isGpt55
+        ? GPT55_RESPONSES_THINKING_LEVEL_MAP
+        : GPT5_RESPONSES_THINKING_LEVEL_MAP,
     };
   }
 

--- a/extensions/sf-llm-gateway-internal/lib/transport.ts
+++ b/extensions/sf-llm-gateway-internal/lib/transport.ts
@@ -254,6 +254,25 @@ export function isOpenAiReasoningModelId(modelId: string): boolean {
  * performs implicit reasoning (live probes show ~30-100 reasoning_tokens on
  * non-trivial prompts even without an explicit effort).
  */
+/**
+ * True for any gpt-5 family model the extension routes through
+ * `POST /responses` (gpt-5, gpt-5-mini, gpt-5.5 and future minor bumps).
+ * Used by the dispatcher in `lib/discovery.ts` to pick the Responses shim.
+ *
+ * Codex (gpt-5.2-codex, gpt-5.3-codex) is deliberately excluded: it has
+ * its own tools/params quirks handled by the chat-path shim, and LiteLLM
+ * maps it to the Responses API upstream anyway, so switching at the proxy
+ * level would double-wrap it.
+ */
+export function isGpt5FamilyResponsesModelId(modelId: string): boolean {
+  if (modelId.toLowerCase().includes("codex")) return false;
+  // Exact allow-list: gpt-5, gpt-5-mini, gpt-5.5 (and openai/... prefixed
+  // variants from LiteLLM's upstream form). Anything else — including
+  // gpt-4o family, future gpt-5.3, and LiteLLM-internal id variants —
+  // stays on the chat-completions path until we have parity evidence.
+  return /^(?:openai\/)?gpt-5(?:-mini|\.5)?$/i.test(modelId.trim());
+}
+
 export function isGpt55ModelId(modelId: string): boolean {
   const lower = modelId.toLowerCase();
   return /(^|\/)gpt-5\.5(?!\d)/.test(lower);
@@ -936,18 +955,28 @@ export function streamSfGatewayOpenAI(
 }
 
 /**
- * Environment variable that forces gpt-5.5 back onto the chat/completions
- * path with `reasoning_effort` stripped — the pre-Phase-3 behavior. Useful
- * as a kill-switch if the Responses-API path starts misbehaving in the wild
- * without requiring a redeploy.
+ * Environment variable that forces the entire gpt-5 family
+ * (gpt-5 / gpt-5-mini / gpt-5.5) back onto the chat/completions path with
+ * `reasoning_effort` stripped or clamped. Kill-switch for the Responses
+ * pivot — flip this if the `/responses` route starts misbehaving in the
+ * wild and you need to recover without a redeploy.
+ *
+ * `GPT55_FORCE_CHAT_ENV` is kept as a backward-compat alias for users who
+ * adopted the narrower name shipped in the first Responses PR.
  */
+export const GPT5_FORCE_CHAT_ENV = "SF_LLM_GATEWAY_INTERNAL_GPT5_FORCE_CHAT";
 export const GPT55_FORCE_CHAT_ENV = "SF_LLM_GATEWAY_INTERNAL_GPT55_FORCE_CHAT";
 
-function shouldForceGpt55Chat(): boolean {
-  const raw = process.env[GPT55_FORCE_CHAT_ENV];
-  if (!raw) return false;
-  const lower = raw.trim().toLowerCase();
+function isTruthyEnv(value: string | undefined): boolean {
+  if (!value) return false;
+  const lower = value.trim().toLowerCase();
   return lower === "1" || lower === "true" || lower === "yes" || lower === "on";
+}
+
+function shouldForceGpt5Chat(): boolean {
+  return (
+    isTruthyEnv(process.env[GPT5_FORCE_CHAT_ENV]) || isTruthyEnv(process.env[GPT55_FORCE_CHAT_ENV])
+  );
 }
 
 /**
@@ -1010,9 +1039,12 @@ export function streamSfGatewayResponses(
   const responsesStreamer = hooks?.responsesStreamer ?? streamSimpleOpenAIResponses;
   const chatStreamer = hooks?.chatStreamer ?? ((m, c, o) => streamSfGatewayOpenAI(m, c, o));
 
-  if (shouldForceGpt55Chat()) {
+  if (shouldForceGpt5Chat()) {
     if (fallback) {
-      fallback.onFallback?.(`${GPT55_FORCE_CHAT_ENV}=1 — using chat completions path`);
+      const envName = isTruthyEnv(process.env[GPT5_FORCE_CHAT_ENV])
+        ? GPT5_FORCE_CHAT_ENV
+        : GPT55_FORCE_CHAT_ENV;
+      fallback.onFallback?.(`${envName}=1 — using chat completions path`);
       return chatStreamer(fallback.chatModel, context, options);
     }
     // No fallback wiring provided (shouldn't happen from the dispatcher,

--- a/extensions/sf-llm-gateway-internal/tests/gpt55-responses.test.ts
+++ b/extensions/sf-llm-gateway-internal/tests/gpt55-responses.test.ts
@@ -19,20 +19,32 @@ import {
   type Context,
   type Model,
 } from "@mariozechner/pi-ai";
-import { toProviderModelConfig, GPT55_RESPONSES_THINKING_LEVEL_MAP } from "../lib/models.ts";
 import {
+  toProviderModelConfig,
+  GPT55_RESPONSES_THINKING_LEVEL_MAP,
+  GPT5_RESPONSES_THINKING_LEVEL_MAP,
+} from "../lib/models.ts";
+import {
+  GPT5_FORCE_CHAT_ENV,
   GPT55_FORCE_CHAT_ENV,
+  isGpt5FamilyResponsesModelId,
   streamSfGatewayResponses,
   type Gpt55ResponsesTestHooks,
 } from "../lib/transport.ts";
 
-const ORIGINAL_ENV = process.env[GPT55_FORCE_CHAT_ENV];
+const ORIGINAL_ENV_55 = process.env[GPT55_FORCE_CHAT_ENV];
+const ORIGINAL_ENV_5 = process.env[GPT5_FORCE_CHAT_ENV];
 
 afterEach(() => {
-  if (ORIGINAL_ENV === undefined) {
-    delete process.env[GPT55_FORCE_CHAT_ENV];
-  } else {
-    process.env[GPT55_FORCE_CHAT_ENV] = ORIGINAL_ENV;
+  for (const [name, original] of [
+    [GPT55_FORCE_CHAT_ENV, ORIGINAL_ENV_55] as const,
+    [GPT5_FORCE_CHAT_ENV, ORIGINAL_ENV_5] as const,
+  ]) {
+    if (original === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = original;
+    }
   }
 });
 
@@ -55,9 +67,47 @@ describe("gpt-5.5 model registration", () => {
     expect(map.xhigh).toBe("high");
   });
 
-  it("does not tag gpt-5 or gpt-5-mini as openai-responses", () => {
-    expect(toProviderModelConfig("gpt-5", null, new Set()).api).toBe("openai-completions");
-    expect(toProviderModelConfig("gpt-5-mini", null, new Set()).api).toBe("openai-completions");
+  it("also tags gpt-5 and gpt-5-mini as openai-responses with the native clamp", () => {
+    for (const id of ["gpt-5", "gpt-5-mini"]) {
+      const cfg = toProviderModelConfig(id, null, new Set());
+      expect(cfg.api).toBe("openai-responses");
+      expect(cfg.thinkingLevelMap).toEqual(GPT5_RESPONSES_THINKING_LEVEL_MAP);
+    }
+  });
+
+  it("keeps codex, gpt-4o, and non-gpt-5 models on openai-completions", () => {
+    for (const id of ["gpt-5.2-codex", "gpt-5.3-codex", "gpt-4o", "gpt-4o-mini"]) {
+      expect(toProviderModelConfig(id, null, new Set()).api).toBe("openai-completions");
+    }
+  });
+});
+
+describe("isGpt5FamilyResponsesModelId", () => {
+  it("matches gpt-5, gpt-5-mini, gpt-5.5 plus the openai/ prefix form", () => {
+    for (const id of [
+      "gpt-5",
+      "gpt-5-mini",
+      "gpt-5.5",
+      "openai/gpt-5",
+      "openai/gpt-5-mini",
+      "openai/gpt-5.5",
+      "GPT-5",
+    ]) {
+      expect(isGpt5FamilyResponsesModelId(id)).toBe(true);
+    }
+  });
+
+  it("does not match codex, gpt-4o, or unrelated ids", () => {
+    for (const id of [
+      "gpt-5.2-codex",
+      "gpt-5.3-codex",
+      "gpt-4o",
+      "gpt-4o-mini",
+      "claude-opus-4-7",
+      "gemini-3.1-pro-preview",
+    ]) {
+      expect(isGpt5FamilyResponsesModelId(id)).toBe(false);
+    }
   });
 });
 
@@ -189,8 +239,8 @@ describe("streamSfGatewayResponses", () => {
     expect(fallbackReason).toMatch(/falling back to chat/i);
   });
 
-  it("respects SF_LLM_GATEWAY_INTERNAL_GPT55_FORCE_CHAT=1 before the first attempt", async () => {
-    process.env[GPT55_FORCE_CHAT_ENV] = "1";
+  it("respects SF_LLM_GATEWAY_INTERNAL_GPT5_FORCE_CHAT=1 before the first attempt", async () => {
+    process.env[GPT5_FORCE_CHAT_ENV] = "1";
     let fallbackReason: string | undefined;
     const hooks: Gpt55ResponsesTestHooks = {
       responsesStreamer: happyResponsesStreamer,
@@ -215,12 +265,39 @@ describe("streamSfGatewayResponses", () => {
     expect(fallbackReason).toMatch(/FORCE_CHAT/i);
   });
 
-  it("ignores unset or falsy values of the force-chat env var", async () => {
+  it("also honors the legacy SF_LLM_GATEWAY_INTERNAL_GPT55_FORCE_CHAT alias", async () => {
+    process.env[GPT55_FORCE_CHAT_ENV] = "1";
+    let fallbackReason: string | undefined;
+    const hooks: Gpt55ResponsesTestHooks = {
+      responsesStreamer: happyResponsesStreamer,
+      chatStreamer: emptyChatStreamer,
+    };
+    await collect(
+      streamSfGatewayResponses(
+        responsesModel,
+        context,
+        undefined,
+        {
+          chatModel,
+          onFallback: (reason) => {
+            fallbackReason = reason;
+          },
+        },
+        hooks,
+      ),
+    );
+    expect(responsesCalls).toBe(0);
+    expect(chatCalls).toBe(1);
+    expect(fallbackReason).toMatch(/GPT55_FORCE_CHAT/i);
+  });
+
+  it("ignores unset or falsy values of the force-chat env vars", async () => {
     const hooks: Gpt55ResponsesTestHooks = {
       responsesStreamer: happyResponsesStreamer,
       chatStreamer: emptyChatStreamer,
     };
 
+    delete process.env[GPT5_FORCE_CHAT_ENV];
     delete process.env[GPT55_FORCE_CHAT_ENV];
     await collect(
       streamSfGatewayResponses(responsesModel, context, undefined, { chatModel }, hooks),
@@ -230,7 +307,8 @@ describe("streamSfGatewayResponses", () => {
 
     responsesCalls = 0;
     chatCalls = 0;
-    process.env[GPT55_FORCE_CHAT_ENV] = "0";
+    process.env[GPT5_FORCE_CHAT_ENV] = "0";
+    process.env[GPT55_FORCE_CHAT_ENV] = "false";
     await collect(
       streamSfGatewayResponses(responsesModel, context, undefined, { chatModel }, hooks),
     );

--- a/extensions/sf-llm-gateway-internal/tests/models.test.ts
+++ b/extensions/sf-llm-gateway-internal/tests/models.test.ts
@@ -311,10 +311,27 @@ describe("toProviderModelConfig", () => {
     expect(config.compat).toBeUndefined();
   });
 
-  it("tags non-Claude models with openai-completions", () => {
+  it("tags non-Claude, non-gpt-5-family models with openai-completions", () => {
     expect(toProviderModelConfig("gemini-2.5-pro", null, new Set()).api).toBe("openai-completions");
-    expect(toProviderModelConfig("gpt-5", null, new Set()).api).toBe("openai-completions");
+    expect(toProviderModelConfig("gpt-4o", null, new Set()).api).toBe("openai-completions");
     expect(toProviderModelConfig("gpt-5.3-codex", null, new Set()).api).toBe("openai-completions");
+  });
+
+  it("routes gpt-5 and gpt-5-mini through openai-responses with the native clamp", () => {
+    // gpt-5 / gpt-5-mini support `minimal | low | medium | high` on the
+    // Responses path but reject `xhigh` upstream. Map passes `minimal`
+    // through (unlike gpt-5.5, which rejects it) and clamps `xhigh → high`.
+    for (const id of ["gpt-5", "gpt-5-mini"]) {
+      const cfg = toProviderModelConfig(id, null, new Set());
+      expect(cfg.api).toBe("openai-responses");
+      expect(cfg.thinkingLevelMap).toEqual({
+        minimal: "minimal",
+        low: "low",
+        medium: "medium",
+        high: "high",
+        xhigh: "high",
+      });
+    }
   });
 
   it("uses the updated GPT-5 272K/128K preset", () => {


### PR DESCRIPTION
Extends the Phase 3 Responses pivot (#66) to the remaining reasoning models in the gpt-5 family. **Also fixes a latent 400 bug.**

## Latent bug fixed

On `main` today, if a user picks `/thinking xhigh` with gpt-5 or gpt-5-mini, every request 400s because the extension sends `xhigh` straight through and upstream OpenAI rejects it.

Live-verified before/after:

```
before: POST /v1/chat/completions  model=gpt-5       reasoning_effort=xhigh → 400 'xhigh not supported'
before: POST /v1/chat/completions  model=gpt-5-mini  reasoning_effort=xhigh → 400 'xhigh not supported'
after : POST /responses            model=gpt-5       reasoning.effort=high (clamped) → 200
after : POST /responses            model=gpt-5-mini  reasoning.effort=high (clamped) → 200
```

## Design

Each model gets a working-window `thinkingLevelMap`:

| Model | minimal | low | medium | high | xhigh |
|---|---|---|---|---|---|
| gpt-5 | minimal | low | medium | high | **→ high** |
| gpt-5-mini | minimal | low | medium | high | **→ high** |
| gpt-5.5 (shipped in #66) | **→ low** | low | medium | high | **→ high** |

gpt-5 / gpt-5-mini tolerate `minimal` upstream — gpt-5.5 doesn't. Both ends of pi's scale clamp where upstream rejects.

## Shared infrastructure (reused from #66)

- **Dispatcher** now keys on `isGpt5FamilyResponsesModelId` — accepts gpt-5, gpt-5-mini, gpt-5.5, and the `openai/...` prefix form. Codex is explicitly excluded.
- **Kill switch** env var generalized to `SF_LLM_GATEWAY_INTERNAL_GPT5_FORCE_CHAT`. The legacy `_GPT55_` name still works for back-compat.
- **Fallback path and baseUrl pinning** unchanged.

## Parity matrix (live, across all 6 pi thinking levels)

Verified on both transports for gpt-5 and gpt-5-mini:

| Level | chat/completions | /responses |
|---|---|---|
| minimal | ✅ works | ✅ works |
| low | ✅ works | ✅ works |
| medium | ✅ works | ✅ works |
| high | ✅ works | ✅ works |
| xhigh | ❌ 400 upstream | ❌ 400 upstream (auto-clamped to high by thinkingLevelMap) |

With the thinkingLevelMap in place, xhigh clamps to high before leaving the client — upstream never sees an unsupported value.

Tool calls verified end-to-end under `xhigh` (→ high):
- gpt-5: `tool_call_seen=true stop=toolUse out_tokens=410`
- gpt-5-mini: `tool_call_seen=true stop=toolUse out_tokens=109`

## Why Responses, not just the clamp?

Per the user's call, for consistency with gpt-5.5's transport. The simpler option was a 5-line clamp-only fix on the chat path. Shipping the full Responses pivot keeps the whole reasoning-capable gpt-5 family on one code path and surfaces the same failure modes through one set of telemetry, which is easier to reason about during dogfooding.

## Tests

- 110/110 on models + transport + gpt55-responses.
- 366/366 on the full extension suite.
- Live smoke test for both new models: https://[redacted] (gateway local to the user).
- Parity-matrix evidence recorded in the commit body.