### PR TITLE
fix(ci): grant statuses:write to auto-merge-release-pr job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,7 @@ jobs:
       pull-requests: write
       actions: write # to re-dispatch release-please
       checks: read # to poll gitleaks status on the same SHA
+      statuses: write # to mirror successful check-runs as commit statuses (POST /repos/.../statuses/{sha})
     steps:
       - name: Resolve PR head branch + SHA
         id: ctx


### PR DESCRIPTION
## Why

Every release-please PR has been stuck in `mergeStateStatus = BLOCKED` because the `Auto-merge release PR` job's "Mirror required check-runs to commit statuses" step fails with:

```
gh: Resource not accessible by integration (HTTP 403)
##[error]Process completed with exit code 1.
```

That step calls `POST /repos/{owner}/{repo}/statuses/{sha}` to mirror successful check-runs onto the head commit (so branch-protection's required-status-checks gate on the release PR is satisfied). The API requires the `statuses` permission scope on `GITHUB_TOKEN`. The job's `permissions:` block grants `contents: write`, `pull-requests: write`, `actions: write`, `checks: read` — but **not `statuses: write`** — so GitHub's least-privilege enforcement returns 403.

Symptom on the most recent attempt:
- v0.51.1 release-please run: failed at 04:00 UTC, 04:15 UTC, 04:17 UTC.
- v0.52.0 release-please run (after PR #94 merged): same failure at 04:44 UTC.

Both runs returned the same 403 on the same step. Releases have been silently piling up.

## Fix

One-line addition to `.github/workflows/ci.yml`:

```yaml
permissions:
  contents: write
  pull-requests: write
  actions: write # to re-dispatch release-please
  checks: read # to poll gitleaks status on the same SHA
+ statuses: write # to mirror successful check-runs as commit statuses (POST /repos/.../statuses/{sha})
```

Scope is the absolute minimum: only the `auto-merge-release-pr` job (which already has elevated permissions for re-dispatching release-please) gets the additional scope. No other job is affected.

## Verification

- `actionlint .github/workflows/ci.yml` — clean.
- After this merges, manually re-run the failed CI on the open release-please PR (#95). The mirror step will succeed, branch-protection will unblock, and release-please's auto-merge logic will fire to ship `v0.52.0` (which carries the pi 0.74 scope migration from #94).

## Risk

Minimal:

- Only adds a permission to a single job that runs only on release-please branches (gated by the `if:` clause that matches `release-please--*` branches).
- No new code paths, no new API calls — just lets the existing API call succeed instead of 403'ing.
- Easy revert: drop the one line.
