### PR TITLE
fix(sf-llm-gateway-internal): preserve explicit model allow-list across restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,16 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 
 ### Bug Fixes
 
+- **sf-llm-gateway-internal: preserve explicit gateway model allow-lists and
+  resolve scoped models from the cached discovery catalog at startup
+  (#163).** The gateway extension now upgrades its 4-entry bootstrap model
+  catalog with the previous discovered catalog before Pi resolves
+  `enabledModels`, so scoped model selection can see models such as
+  `gpt-5.5`, Gemini, and Codex immediately on restart. The settings repair
+  pass also no longer collapses user-authored
+  `sf-llm-gateway-internal/<model-id>` entries to the wildcard; only the
+  retired `sf-llm-gateway-internal-anthropic/*` provider pattern is treated
+  as legacy.
 - **sf-pi-manager: auto-detect scope for `/sf-pi` commands so a project-only
   install of sf-pi works without typing `project` on every command
   (#88).** `parseCommandArgs` previously hardcoded the default scope to

--- a/catalog/index.json
+++ b/catalog/index.json
@@ -320,7 +320,7 @@
     "entry": "extensions/sf-llm-gateway-internal/index.ts",
     "hasReadme": true,
     "hasTests": true,
-    "srcLoc": 9172
+    "srcLoc": 9184
   },
   {
     "id": "sf-lsp",

--- a/extensions/sf-llm-gateway-internal/index.ts
+++ b/extensions/sf-llm-gateway-internal/index.ts
@@ -331,6 +331,15 @@ export default function sfLlmGatewayInternalExtension(pi: ExtensionAPI) {
   // reads global saved config first, then env vars as automation fallback.
   registerProviderIfConfigured(pi, getBetaOverrides(), getBetaExtras());
 
+  // Upgrade the bootstrap catalog with the previous run's discovered
+  // catalog (when available) BEFORE Pi resolves `enabledModels` patterns.
+  // Without this, `sf-llm-gateway-internal/*` and explicit allow-list
+  // entries like `sf-llm-gateway-internal/gpt-5.5` resolve against just
+  // the 4-model bootstrap list and miss every other discovered model for
+  // the rest of the session. The session_start handler re-runs this with
+  // project-aware cwd; the deferred network discovery refreshes both.
+  registerCachedDiscoveryIfAvailable(pi, getBetaOverrides(), getBetaExtras());
+
   // Contribute to the aggregated `/sf-pi doctor` view. The standalone
   // `/sf-llm-gateway-internal doctor` command keeps using
   // fetchGatewayDoctorReport directly for backwards-compat rendering.

--- a/extensions/sf-llm-gateway-internal/lib/discovery.ts
+++ b/extensions/sf-llm-gateway-internal/lib/discovery.ts
@@ -174,9 +174,13 @@ export function registerCachedDiscoveryIfAvailable(
   pi: ExtensionAPI,
   runtimeBetaOverrides: Set<string> | null,
   runtimeExtraBetas: Set<string>,
-  cwd: string,
+  cwd?: string,
 ): boolean {
-  const config = getGatewayConfig(cwd);
+  // Mirror `registerProviderIfConfigured`'s factory-fallback pattern: when no
+  // cwd is supplied (extension factory time, before session_start), read the
+  // global-only saved config / env vars. session_start re-runs this with the
+  // session's project-aware cwd to pick up any project overrides.
+  const config = cwd ? getGatewayConfig(cwd) : getGlobalOnlyGatewayConfig();
   if (!config.enabled || !config.baseUrl) return false;
 
   const cache = readDiscoveryCache();

--- a/extensions/sf-llm-gateway-internal/lib/pi-settings.ts
+++ b/extensions/sf-llm-gateway-internal/lib/pi-settings.ts
@@ -28,7 +28,6 @@ import {
   asOptionalString,
 } from "./config.ts";
 
-const ENABLED_MODEL_PREFIX = ENABLED_MODEL_PATTERN.slice(0, -1);
 const LEGACY_ENABLED_MODEL_PREFIX_ANTHROPIC = LEGACY_ENABLED_MODEL_PATTERN_ANTHROPIC.slice(0, -1);
 
 /**
@@ -93,10 +92,11 @@ export function isExclusiveEnabledModelPattern(value: unknown): boolean {
 
 function isLegacyGatewayModelPattern(pattern: string): boolean {
   if (isGatewayScopePattern(pattern)) return false;
-  return (
-    pattern.startsWith(ENABLED_MODEL_PREFIX) ||
-    pattern.startsWith(LEGACY_ENABLED_MODEL_PREFIX_ANTHROPIC)
-  );
+  // Only the retired `-anthropic` sub-provider wildcard is truly legacy.
+  // Specific current-provider entries like `sf-llm-gateway-internal/gpt-5.5`
+  // are valid user-authored allow-list patterns and must be preserved as-is
+  // — collapsing them to the wildcard erases the user's intentional scope.
+  return pattern.startsWith(LEGACY_ENABLED_MODEL_PREFIX_ANTHROPIC);
 }
 
 /**

--- a/extensions/sf-llm-gateway-internal/tests/config.test.ts
+++ b/extensions/sf-llm-gateway-internal/tests/config.test.ts
@@ -220,13 +220,16 @@ describe("removeEnabledModelPattern", () => {
 describe("normalizeLegacyGatewayEnabledModels", () => {
   const PATTERN = "sf-llm-gateway-internal/*";
 
-  it("collapses legacy gateway-only exact model entries to the provider wildcard", () => {
+  it("preserves user-authored exact gateway model allow-lists as-is", () => {
+    // Specific gateway models like sf-llm-gateway-internal/<id> are valid
+    // current-provider allow-list entries; collapsing them to the wildcard
+    // would erase the user's intentional scope choice.
     expect(
       normalizeLegacyGatewayEnabledModels([
         "sf-llm-gateway-internal/claude-opus-4-7",
         "sf-llm-gateway-internal/gpt-5",
       ]),
-    ).toEqual([PATTERN]);
+    ).toEqual(["sf-llm-gateway-internal/claude-opus-4-7", "sf-llm-gateway-internal/gpt-5"]);
   });
 
   it("collapses the retired anthropic sub-provider wildcard to the unified wildcard", () => {
@@ -235,20 +238,23 @@ describe("normalizeLegacyGatewayEnabledModels", () => {
     ).toEqual([PATTERN, "openai/*"]);
   });
 
-  it("preserves non-gateway patterns while collapsing legacy gateway entries", () => {
+  it("preserves user-authored gateway entries alongside non-gateway patterns", () => {
     expect(
       normalizeLegacyGatewayEnabledModels([
         "sf-llm-gateway-internal/gpt-5",
         "openai/*",
         "anthropic/*",
       ]),
-    ).toEqual([PATTERN, "openai/*", "anthropic/*"]);
+    ).toEqual(["sf-llm-gateway-internal/gpt-5", "openai/*", "anthropic/*"]);
   });
 
-  it("removes redundant exact gateway entries next to the wildcard", () => {
+  it("keeps explicit gateway entries even when the wildcard is also present", () => {
+    // A mixed list (wildcard + specific ids) is unusual but valid — the
+    // specific ids resolve first under glob semantics and any extras under
+    // the wildcard. We must not silently drop the explicit entries.
     expect(
       normalizeLegacyGatewayEnabledModels([PATTERN, "sf-llm-gateway-internal/gpt-5", "openai/*"]),
-    ).toEqual([PATTERN, "openai/*"]);
+    ).toEqual([PATTERN, "sf-llm-gateway-internal/gpt-5", "openai/*"]);
   });
 
   it("leaves non-gateway scopes unchanged", () => {


### PR DESCRIPTION
## What this PR does

Fixes `sf-llm-gateway-internal` model scoping so explicit gateway model allow-lists are preserved across restarts and scoped model selection can resolve from the cached discovered gateway catalog instead of being frozen to the 4-model bootstrap list.

## Why

Users who set an explicit gateway model scope like:

```json
"enabledModels": [
  "sf-llm-gateway-internal/claude-opus-4-7",
  "sf-llm-gateway-internal/gpt-5.5",
  "sf-llm-gateway-internal/gemini-3.1-pro-preview"
]
```

were still seeing only the 4 bootstrap models in `/model` tab:

- `claude-opus-4-7`
- `claude-opus-4-6-v1`
- `claude-sonnet-4-6`
- `gpt-5`

and their explicit `enabledModels` entries were silently rewritten to `sf-llm-gateway-internal/*` on the next session start.

Closes #163

## How

- Register the cached discovered gateway catalog from the extension factory immediately after the static bootstrap registration.
  - This makes cached discovered IDs available before Pi resolves `enabledModels` patterns into `session.scopedModels`.
  - `registerCachedDiscoveryIfAvailable` now accepts optional `cwd` and falls back to `getGlobalOnlyGatewayConfig()` when called from the factory, preserving the existing 0.68.0 “no `process.cwd()` in factory” rule.
  - The `session_start` call remains in place and re-runs with project-aware `ctx.cwd`; deferred live discovery still refreshes after first paint.
- Tighten `isLegacyGatewayModelPattern` so it only treats the retired `sf-llm-gateway-internal-anthropic/*` provider pattern as legacy.
  - Current-provider entries like `sf-llm-gateway-internal/gpt-5.5` are now preserved as valid user-authored allow-list patterns.
- Update config tests that previously codified the destructive collapse behavior.
- Add an Unreleased changelog entry.

## Checklist

- [ ] I ran `npm run validate` locally
- [x] README update not needed (fixes startup/settings preservation; no user-facing command/API docs changed)
- [x] I added or updated tests
- [x] I regenerated the catalog (`npm run generate-catalog`) if I touched `manifest.json`
- [x] I added a `CHANGELOG.md` entry under `[Unreleased]`
- [x] This PR is non-breaking, or I called out the breaking change explicitly above

## Notes for reviewers

Validation performed locally:

- `npx vitest run` → 206 files / 1941 tests passing
- `npm run lint` → passing
- Additional targeted rerun after changelog: `npx vitest run extensions/sf-llm-gateway-internal/tests/config.test.ts extensions/sf-llm-gateway-internal/tests/cwd-migration.test.ts extensions/sf-llm-gateway-internal/tests/discovery-cache.test.ts` → passing
- Live smoke test in Pi: after restart, `/model` scoped tab shows the user’s explicit 6-entry gateway allow-list and `settings.json.enabledModels` remains unchanged across restart.

I did not mark `npm run validate` as checked because I ran the repo test suite and lint directly rather than the wrapper script.
