### PR TITLE
fix(sf-pi-manager): scroll extension list on small terminals

### DIFF
--- a/catalog/index.json
+++ b/catalog/index.json
@@ -435,7 +435,7 @@
     "entry": "extensions/sf-pi-manager/index.ts",
     "hasReadme": true,
     "hasTests": true,
-    "srcLoc": 3374
+    "srcLoc": 3461
   },
   {
     "id": "sf-skills",

--- a/extensions/sf-pi-manager/index.ts
+++ b/extensions/sf-pi-manager/index.ts
@@ -477,7 +477,7 @@ async function handleOverlay(
   let result: OverlayResult | undefined;
   try {
     result = await ctx.ui.custom<OverlayResult | undefined>(
-      (_tui, theme, _keybindings, done) =>
+      (tui, theme, _keybindings, done) =>
         new SfPiOverlayComponent(
           theme,
           PACKAGE_VERSION,
@@ -486,6 +486,7 @@ async function handleOverlay(
           extensions,
           SF_PI_REGISTRY,
           scope,
+          () => tui.terminal.rows,
           done,
         ),
       {

--- a/extensions/sf-pi-manager/lib/overlay.ts
+++ b/extensions/sf-pi-manager/lib/overlay.ts
@@ -47,6 +47,11 @@ type ConfigPanel = Component &
     renderContent?: (width: number) => string[];
   };
 
+const LIST_MAX_TERMINAL_FRACTION = 0.85;
+const LIST_NON_VIEWPORT_ROWS = 7;
+const EXTENSION_ROW_HEIGHT = 3;
+const MIN_VISIBLE_EXTENSIONS = 2;
+
 // -------------------------------------------------------------------------------------------------
 // Types
 // -------------------------------------------------------------------------------------------------
@@ -111,6 +116,7 @@ export class SfPiOverlayComponent implements Focusable {
   focused = false;
 
   private selectedIndex = 0;
+  private listScrollOffset = 0;
   private extensions: ExtensionState[];
   private changed = false;
   private view: OverlayView = { kind: "list" };
@@ -132,6 +138,7 @@ export class SfPiOverlayComponent implements Focusable {
     initialStates: ExtensionState[],
     private readonly registryEntries: readonly SfPiExtension[],
     initialScope: "global" | "project",
+    private readonly getTerminalRows: () => number,
     private readonly done: (result: OverlayResult | undefined) => void,
   ) {
     this.extensions = initialStates.map((e) => ({ ...e }));
@@ -238,9 +245,11 @@ export class SfPiOverlayComponent implements Focusable {
     const innerWidth = Math.max(50, width - 2);
     const theme = this.theme;
 
-    const row = (content: string = "") => {
-      const padded = padAnsi(truncateToWidth(content, innerWidth, ""), innerWidth);
-      return `${theme.fg("border", "│")}${padded}${theme.fg("border", "│")}`;
+    const row = (content: string = "", scrollBar: string = "") => {
+      const scrollBarWidth = scrollBar ? 1 : 0;
+      const contentWidth = Math.max(1, innerWidth - scrollBarWidth);
+      const padded = padAnsi(truncateToWidth(content, contentWidth, ""), contentWidth);
+      return `${theme.fg("border", "│")}${padded}${scrollBar}${theme.fg("border", "│")}`;
     };
 
     if (this.view.kind === "detail") {
@@ -258,12 +267,33 @@ export class SfPiOverlayComponent implements Focusable {
   // List view rendering
   // -------------------------------------------------------------------------------------------------
 
-  private renderListView(innerWidth: number, row: (content?: string) => string): string[] {
+  private renderListView(
+    innerWidth: number,
+    row: (content?: string, scrollBar?: string) => string,
+  ): string[] {
     const lines: string[] = [];
     const theme = this.theme;
     const enabledCount = this.extensions.filter((e) => e.enabled).length;
     const totalCount = this.extensions.length;
+    const visibleCount = this.getVisibleExtensionCount();
+    this.ensureSelectionVisible(visibleCount);
+
     const selected = this.extensions[this.selectedIndex];
+    const visibleExtensions = this.extensions.slice(
+      this.listScrollOffset,
+      this.listScrollOffset + visibleCount,
+    );
+    const needsScrollbar = totalCount > visibleCount;
+    const listContentWidth = needsScrollbar ? innerWidth - 1 : innerWidth;
+    const listViewportRows = Math.max(1, visibleExtensions.length * EXTENSION_ROW_HEIGHT - 1);
+    let listViewportRowIndex = 0;
+    const listRow = (content: string = "") =>
+      row(
+        content,
+        needsScrollbar
+          ? this.renderListScrollbar(listViewportRowIndex++, listViewportRows, visibleCount)
+          : "",
+      );
 
     lines.push(theme.fg("border", `╭${"─".repeat(innerWidth)}╮`));
 
@@ -282,8 +312,10 @@ export class SfPiOverlayComponent implements Focusable {
     );
     lines.push(row(""));
 
-    for (let i = 0; i < this.extensions.length; i++) {
-      const ext = this.extensions[i];
+    for (let localIndex = 0; localIndex < visibleExtensions.length; localIndex++) {
+      const ext = visibleExtensions[localIndex];
+      if (!ext) continue;
+      const i = this.listScrollOffset + localIndex;
       const isSelected = i === this.selectedIndex;
 
       const indicator = this.renderStatusIndicator(getExtensionStatus(ext));
@@ -298,15 +330,20 @@ export class SfPiOverlayComponent implements Focusable {
       const configBadge = ext.configurable ? theme.fg("accent", "⚙") : "";
       const rightParts = [configBadge, stateBadge, categoryTag].filter(Boolean).join(" ");
       const leftPart = ` ${cursor} ${indicator} ${name}`;
-      const gap = Math.max(2, innerWidth - visibleWidth(leftPart) - visibleWidth(rightParts) - 1);
-
-      lines.push(row(`${leftPart}${" ".repeat(gap)}${rightParts}`));
-      lines.push(
-        row(`     ${theme.fg(ext.enabled || ext.alwaysActive ? "dim" : "muted", ext.description)}`),
+      const gap = Math.max(
+        2,
+        listContentWidth - visibleWidth(leftPart) - visibleWidth(rightParts) - 1,
       );
 
-      if (i < this.extensions.length - 1) {
-        lines.push(row(""));
+      lines.push(listRow(`${leftPart}${" ".repeat(gap)}${rightParts}`));
+      lines.push(
+        listRow(
+          `     ${theme.fg(ext.enabled || ext.alwaysActive ? "dim" : "muted", ext.description)}`,
+        ),
+      );
+
+      if (localIndex < visibleExtensions.length - 1) {
+        lines.push(listRow(""));
       }
     }
 
@@ -322,7 +359,12 @@ export class SfPiOverlayComponent implements Focusable {
       );
     }
 
-    const countText = theme.fg("muted", `Enabled: ${enabledCount}/${totalCount} extensions`);
+    const visibleStart = totalCount === 0 ? 0 : this.listScrollOffset + 1;
+    const visibleEnd = Math.min(totalCount, this.listScrollOffset + visibleCount);
+    const countText = theme.fg(
+      "muted",
+      `Enabled: ${enabledCount}/${totalCount} extensions · Showing ${visibleStart}-${visibleEnd}`,
+    );
     const changedText = this.changed ? theme.fg("warning", " (unsaved changes)") : "";
     const reloadText = this.configPanelReloadNeeded ? theme.fg("warning", " (reload pending)") : "";
     lines.push(row(` ${countText}${changedText}${reloadText}`));
@@ -505,6 +547,60 @@ export class SfPiOverlayComponent implements Focusable {
     return this.extensions.find((ext) => ext.id === detailView.extensionId);
   }
 
+  private getVisibleExtensionCount(): number {
+    const terminalRows = Math.max(1, this.getTerminalRows());
+    const overlayRows = Math.max(1, Math.floor(terminalRows * LIST_MAX_TERMINAL_FRACTION));
+    const availableListRows = Math.max(
+      EXTENSION_ROW_HEIGHT * MIN_VISIBLE_EXTENSIONS,
+      overlayRows - LIST_NON_VIEWPORT_ROWS,
+    );
+    const visibleCount = Math.max(
+      MIN_VISIBLE_EXTENSIONS,
+      Math.floor((availableListRows + 1) / EXTENSION_ROW_HEIGHT),
+    );
+
+    return Math.min(this.extensions.length, visibleCount);
+  }
+
+  private ensureSelectionVisible(visibleCount = this.getVisibleExtensionCount()): void {
+    if (this.extensions.length === 0) {
+      this.selectedIndex = 0;
+      this.listScrollOffset = 0;
+      return;
+    }
+
+    this.selectedIndex = Math.max(0, Math.min(this.selectedIndex, this.extensions.length - 1));
+
+    const maxOffset = Math.max(0, this.extensions.length - visibleCount);
+    if (this.selectedIndex < this.listScrollOffset) {
+      this.listScrollOffset = this.selectedIndex;
+    } else if (this.selectedIndex >= this.listScrollOffset + visibleCount) {
+      this.listScrollOffset = this.selectedIndex - visibleCount + 1;
+    }
+
+    this.listScrollOffset = Math.max(0, Math.min(this.listScrollOffset, maxOffset));
+  }
+
+  private renderListScrollbar(
+    viewportRowIndex: number,
+    viewportRows: number,
+    visibleCount: number,
+  ): string {
+    if (this.extensions.length <= visibleCount || viewportRows <= 0) {
+      return "";
+    }
+
+    const maxOffset = Math.max(1, this.extensions.length - visibleCount);
+    const thumbRows = Math.max(
+      1,
+      Math.round((visibleCount / this.extensions.length) * viewportRows),
+    );
+    const thumbStart = Math.round((this.listScrollOffset / maxOffset) * (viewportRows - thumbRows));
+    const isThumb = viewportRowIndex >= thumbStart && viewportRowIndex < thumbStart + thumbRows;
+
+    return this.theme.fg(isThumb ? "accent" : "dim", isThumb ? "█" : "│");
+  }
+
   private renderStatusIndicator(status: ReturnType<typeof getExtensionStatus>): string {
     if (status === "locked") {
       return this.theme.fg("accent", "◆");
@@ -552,6 +648,7 @@ export class SfPiOverlayComponent implements Focusable {
     if (next >= len) next = 0;
 
     this.selectedIndex = next;
+    this.ensureSelectionVisible();
   }
 
   private toggleSelected(): void {


### PR DESCRIPTION
Fixes #174

## Summary

On small terminal heights, the `/sf-pi` extension manager overlay rendered the
full extension list below the visible fold, and arrow-key navigation could move
the selection off-screen with no scroll feedback. This only became visible on
laptop screens — the dev/test loop on large external monitors didn't surface it
because the full list fits.

## Changes

- Compute a visible-extension viewport from `tui.terminal.rows` instead of
  rendering the entire registry every frame.
- Track `listScrollOffset` and `ensureSelectionVisible()` so moving the cursor
  past the bottom or top of the viewport scrolls the list to keep the selection
  in view (with wrap-around preserved at the list ends).
- Draw a right-side scrollbar inside the list area when not all extensions fit,
  with a thumb sized and positioned from the current scroll offset.
- Footer now also reports `Showing X-Y` so the visible slice is explicit.
- On terminals tall enough to fit every extension (large monitors), no
  scrollbar is drawn and behavior is unchanged.

## Validation

- `npm run check` — passes
- `npm test -- extensions/sf-pi-manager/tests` — 13 files, 137 tests pass
- `npm run lint` — passes (prettier / generate-catalog / docs-health / spdx / eslint)
- Manual: opened `/sf-pi` on a ~24-row terminal, navigated through all 13
  extensions; selection stays visible, scrollbar thumb tracks position.

## Notes for reviewers

- Viewport sizing constants live in `extensions/sf-pi-manager/lib/overlay.ts`
  (`LIST_MAX_TERMINAL_FRACTION`, `LIST_NON_VIEWPORT_ROWS`,
  `EXTENSION_ROW_HEIGHT`, `MIN_VISIBLE_EXTENSIONS`).
- `SfPiOverlayComponent` now takes a `getTerminalRows` callback so the
  component stays test-friendly without depending on the real `TUI` instance.
- `catalog/index.json` regenerated via `npm run generate-catalog` — only the
  `srcLoc` for `sf-pi-manager` changed, picked up automatically by the husky
  pre-commit hook.

I'll sign the Salesforce CLA at <https://cla.salesforce.com/sign-cla> as part
of the PR check.