### PR TITLE
feat(sf-welcome): add SF Skills row tracking forcedotcom/afv-library

### DIFF
--- a/catalog/index.json
+++ b/catalog/index.json
@@ -587,6 +587,6 @@
     "entry": "extensions/sf-welcome/index.ts",
     "hasReadme": true,
     "hasTests": true,
-    "srcLoc": 3776
+    "srcLoc": 4338
   }
 ]

--- a/extensions/sf-welcome/README.md
+++ b/extensions/sf-welcome/README.md
@@ -157,6 +157,7 @@ extensions/sf-welcome/
     recommendations-status.ts← implementation module
     session-data.ts         ← implementation module
     sf-cli-status.ts        ← implementation module
+    sf-skills-status.ts     ← implementation module
     splash-component.ts     ← implementation module
     splash-data.ts          ← implementation module
     startup-mode.ts         ← implementation module
@@ -173,8 +174,10 @@ extensions/sf-welcome/
     recommendations-status.test.ts← unit / smoke test
     sdk-migration.test.ts   ← unit / smoke test
     sf-cli-status.test.ts   ← unit / smoke test
+    sf-skills-status.test.ts← unit / smoke test
     smoke.test.ts           ← unit / smoke test
     splash-privacy.test.ts  ← unit / smoke test
+    splash-sf-skills.test.ts← unit / smoke test
     startup-mode.test.ts    ← unit / smoke test
     state-store.test.ts     ← unit / smoke test
     whats-new.test.ts       ← unit / smoke test

--- a/extensions/sf-welcome/index.ts
+++ b/extensions/sf-welcome/index.ts
@@ -70,11 +70,14 @@ import {
   collectInitialSplashData,
   collectSplashData,
   detectSfCliStatus,
+  detectSfSkillsStatus,
   readCachedSfCliStatus,
+  readCachedSfSkillsStatus,
   readCurrentPiVersion,
   refreshAnnouncementsSummary,
   resolveMonthlyUsage,
   writeCachedSfCliStatus,
+  writeCachedSfSkillsStatus,
 } from "./lib/splash-data.ts";
 import { acknowledgeAnnouncementsRevision } from "../../lib/common/catalog-state/announcements-state.ts";
 import { SfWelcomeOverlay, SfWelcomeHeader } from "./lib/splash-component.ts";
@@ -391,6 +394,12 @@ export default function sfWelcome(pi: ExtensionAPI) {
     if (cachedSfCli) {
       data.sfCli = cachedSfCli;
     }
+    // sf-skills status is also cache-first — the deferred refresh below
+    // populates the live value and writes back to disk for the next launch.
+    const cachedSfSkills = readCachedSfSkillsStatus();
+    if (cachedSfSkills) {
+      data.sfSkills = cachedSfSkills;
+    }
     const doctorReport = runDoctorDiagnostics({ cwd: ctx.cwd });
     data.doctor = summarizeStartupDoctorNudge(doctorReport) ?? undefined;
 
@@ -513,6 +522,32 @@ export default function sfWelcome(pi: ExtensionAPI) {
         });
     }, 2_000);
     sfCliTimer.unref?.();
+
+    // Background sf-skills status: same cache-first pattern as the CLI row
+    // but staggered 500 ms after it so the two network probes (npm registry
+    // + GitHub compare API) don't pile up on the same event-loop tick. The
+    // local FS detection is sync and cheap (~1 ms); the network call is the
+    // only thing that's deferred.
+    const sfSkillsTimer = setTimeout(() => {
+      if (runId !== startupRunId || !isActiveSession(ctx, generation)) return;
+      void markBootStep("sf-welcome.sf-skills-detect", () => detectSfSkillsStatus(ctx.cwd))
+        .then((skills) => {
+          writeCachedSfSkillsStatus(skills);
+          if (runId !== startupRunId || !isActiveSession(ctx, generation)) return;
+          data.sfSkills = skills;
+          scheduleSplashRepaint(ctx, generation);
+        })
+        .catch(() => {
+          if (runId !== startupRunId || !isActiveSession(ctx, generation)) return;
+          // Detection itself never throws — this catch is defensive only.
+          // Keep whatever cache the splash already painted with.
+          if (!data.sfSkills) {
+            data.sfSkills = { installKind: "not-installed", freshness: "unknown", loading: false };
+            scheduleSplashRepaint(ctx, generation);
+          }
+        });
+    }, 2_500);
+    sfSkillsTimer.unref?.();
 
     // Subscribe to the gateway usage store so any time the provider publishes
     // a new snapshot (first populate, periodic refresh, /sf-llm-gateway-internal

--- a/extensions/sf-welcome/lib/sf-skills-status.ts
+++ b/extensions/sf-welcome/lib/sf-skills-status.ts
@@ -1,0 +1,443 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/**
+ * forcedotcom/afv-library install + freshness status for the welcome splash.
+ *
+ * The companion `sf-skills` extension owns the install / update / link
+ * lifecycle. This module is a strictly read-only sibling that surfaces a
+ * single splash row:
+ *
+ *     📚 SF Skills    ✓ afv-library installed · latest
+ *     📚 SF Skills    ↑ afv-library · 12 commits behind
+ *     📚 SF Skills    ✓ afv-library linked · ~/work/afv-library
+ *     📚 SF Skills    ↑ Install official skills (·  /sf-skills defaults install)
+ *
+ * Design rules (must hold so startup time stays flat):
+ *
+ *   1. First paint is purely local. existsSync() + cache read. No git, no
+ *      subprocess, no fetch.
+ *   2. Background refresh runs on a deferred timer (see index.ts). The local
+ *      commit SHA comes from `.git/HEAD` directly so we avoid a `git`
+ *      subprocess in the common case (depth-1 clones from
+ *      `/sf-skills defaults install` always satisfy this).
+ *   3. The upstream comparison hits GitHub's compare endpoint with a 5 s
+ *      timeout. Failure degrades to `freshness: "unknown"` — we never
+ *      throw out of detection.
+ *   4. On-disk cache lives under the canonical sf-pi/<ns>/<file> layout via
+ *      the shared state-store, with a 24 h TTL identical to sf-cli-status.
+ *
+ * Re-uses `inspectManagedClone()` from extensions/sf-skills/lib/defaults.ts as
+ * the source of truth for managed-clone paths so the two extensions can never
+ * disagree on where the repo lives.
+ */
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+import { homedir } from "node:os";
+import { createStateStore } from "../../../lib/common/state-store.ts";
+import { globalSettingsPath, projectSettingsPath } from "../../../lib/common/pi-paths.ts";
+import { inspectManagedClone } from "../../sf-skills/lib/defaults.ts";
+import type { SfSkillsStatusInfo } from "./types.ts";
+
+// -------------------------------------------------------------------------------------------------
+// Constants
+// -------------------------------------------------------------------------------------------------
+
+const REPO_OWNER = "forcedotcom";
+const REPO_NAME = "afv-library";
+const REPO_DEFAULT_BRANCH = "main";
+const GITHUB_COMPARE_TIMEOUT_MS = 5_000;
+const CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+// -------------------------------------------------------------------------------------------------
+// State-store cache (mirrors sf-cli-status.ts)
+// -------------------------------------------------------------------------------------------------
+
+interface SfSkillsStatusCacheFile {
+  status?: SfSkillsStatusInfo;
+  savedAt?: number;
+}
+
+/**
+ * Build a fresh state-store on every call so PI_CODING_AGENT_DIR overrides
+ * applied after module load (notably in unit tests, but also in any pi SDK
+ * consumer that boots with a custom agent dir) reach the cache path. The
+ * factory call itself does no I/O — it just wires closures — so the
+ * recomputation cost is negligible compared to the FS read/write that
+ * follows.
+ */
+function getCacheStore() {
+  return createStateStore<SfSkillsStatusCacheFile>({
+    namespace: "sf-welcome",
+    filename: "sf-skills-status.json",
+    schemaVersion: 1,
+    defaults: {},
+    migrate(raw, fromVersion) {
+      if (fromVersion !== 0) return null;
+      return raw && typeof raw === "object" && !Array.isArray(raw)
+        ? (raw as SfSkillsStatusCacheFile)
+        : null;
+    },
+  });
+}
+
+function parseCachedStatus(value: unknown): SfSkillsStatusInfo | null {
+  if (!value || typeof value !== "object") return null;
+  const record = value as Partial<SfSkillsStatusInfo>;
+  if (
+    record.installKind !== "managed" &&
+    record.installKind !== "linked" &&
+    record.installKind !== "not-installed"
+  ) {
+    return null;
+  }
+  if (
+    record.freshness !== "checking" &&
+    record.freshness !== "latest" &&
+    record.freshness !== "update-available" &&
+    record.freshness !== "unknown"
+  ) {
+    return null;
+  }
+  return {
+    installKind: record.installKind,
+    scope: record.scope === "global" || record.scope === "project" ? record.scope : undefined,
+    skillsPath: typeof record.skillsPath === "string" ? record.skillsPath : undefined,
+    rootPath: typeof record.rootPath === "string" ? record.rootPath : undefined,
+    localSha: typeof record.localSha === "string" ? record.localSha : undefined,
+    remoteSha: typeof record.remoteSha === "string" ? record.remoteSha : undefined,
+    commitsBehind:
+      typeof record.commitsBehind === "number" && Number.isFinite(record.commitsBehind)
+        ? record.commitsBehind
+        : undefined,
+    skillCount:
+      typeof record.skillCount === "number" && Number.isFinite(record.skillCount)
+        ? record.skillCount
+        : undefined,
+    freshness: record.freshness,
+    // Cached values are display-ready; a background refresh may update them.
+    loading: false,
+  };
+}
+
+export function readCachedSfSkillsStatus(
+  maxAgeMs: number = CACHE_MAX_AGE_MS,
+): SfSkillsStatusInfo | null {
+  try {
+    const cache = getCacheStore().read();
+    if (typeof cache.savedAt !== "number") return null;
+    if (Date.now() - cache.savedAt > maxAgeMs) return null;
+    return parseCachedStatus(cache.status);
+  } catch {
+    return null;
+  }
+}
+
+export function writeCachedSfSkillsStatus(status: SfSkillsStatusInfo): void {
+  try {
+    getCacheStore().write({ status: { ...status, loading: false }, savedAt: Date.now() });
+  } catch {
+    // Cache is best-effort. Never let splash rendering depend on disk writes.
+  }
+}
+
+// -------------------------------------------------------------------------------------------------
+// Local detection (sync, FS-only)
+// -------------------------------------------------------------------------------------------------
+
+/**
+ * Read the commit SHA pointed to by HEAD without spawning git.
+ *
+ * Depth-1 clones produced by `/sf-skills defaults install` always have the
+ * branch tip in a loose ref under .git/refs/heads/<branch>, so this returns
+ * a SHA in the common case. Falls back to packed-refs and finally to
+ * `undefined` so the caller can degrade to freshness:"unknown".
+ */
+export function readLocalGitHead(rootPath: string): string | undefined {
+  try {
+    const headPath = path.join(rootPath, ".git", "HEAD");
+    if (!existsSync(headPath)) return undefined;
+    const head = readFileSync(headPath, "utf8").trim();
+    // Detached HEAD or already-resolved SHA.
+    if (/^[0-9a-f]{7,64}$/.test(head)) return head;
+    // Symbolic ref: "ref: refs/heads/main"
+    const match = head.match(/^ref:\s*(.+)$/);
+    if (!match) return undefined;
+    const refPath = match[1].trim();
+    const loose = path.join(rootPath, ".git", refPath);
+    if (existsSync(loose)) {
+      const sha = readFileSync(loose, "utf8").trim();
+      if (/^[0-9a-f]{7,64}$/.test(sha)) return sha;
+    }
+    // Fall back to packed-refs lookup.
+    const packed = path.join(rootPath, ".git", "packed-refs");
+    if (existsSync(packed)) {
+      const lines = readFileSync(packed, "utf8").split("\n");
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith("#")) continue;
+        const [sha, ref] = trimmed.split(/\s+/);
+        if (ref === refPath && /^[0-9a-f]{7,64}$/.test(sha)) return sha;
+      }
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Count subdirectories under <skillsPath>/ that contain a SKILL.md.
+ *
+ * Best-effort and bounded: walks one level deep, no recursion. If anything
+ * throws we return undefined so the row doesn't grow noisy with a misleading
+ * count.
+ */
+export function countSkillsInDir(skillsPath: string): number | undefined {
+  if (!existsSync(skillsPath)) return undefined;
+  try {
+    let count = 0;
+    for (const entry of readdirSync(skillsPath)) {
+      const entryPath = path.join(skillsPath, entry);
+      try {
+        if (statSync(entryPath).isDirectory() && existsSync(path.join(entryPath, "SKILL.md"))) {
+          count++;
+        }
+      } catch {
+        // Skip unreadable entries — never crash the splash here.
+      }
+    }
+    return count;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Scan global + project settings.skills[] for an entry that looks like a
+ * user-owned afv-library checkout (linked, but not managed by us).
+ *
+ * Returns the rootPath of the first matching checkout, plus the scope it
+ * was wired in. We accept any path whose final segment is "skills" and
+ * whose parent directory has a `.git` entry — that matches both literal
+ * `~/.../afv-library/skills` clones and forks renamed to other names. We
+ * intentionally don't require "afv-library" in the path so renamed forks
+ * still register as installed.
+ */
+export function detectLinkedAfvCheckout(
+  cwd: string,
+): { rootPath: string; skillsPath: string; scope: "global" | "project" } | null {
+  const candidates: Array<{ filePath: string; scope: "global" | "project" }> = [
+    { filePath: globalSettingsPath(), scope: "global" },
+    { filePath: projectSettingsPath(cwd), scope: "project" },
+  ];
+
+  for (const { filePath, scope } of candidates) {
+    if (!existsSync(filePath)) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(filePath, "utf8"));
+    } catch {
+      continue;
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) continue;
+    const skills = (parsed as Record<string, unknown>).skills;
+    if (!Array.isArray(skills)) continue;
+
+    for (const value of skills) {
+      if (typeof value !== "string" || !value.trim()) continue;
+      const expanded = expandPath(value, cwd);
+      if (path.basename(expanded) !== "skills") continue;
+      const rootPath = path.dirname(expanded);
+      const gitMarker = path.join(rootPath, ".git");
+      if (!existsSync(gitMarker)) continue;
+      // Skip the managed paths; those are reported via inspectManagedClone.
+      if (looksLikeManagedClone(rootPath)) continue;
+      return { rootPath, skillsPath: expanded, scope };
+    }
+  }
+  return null;
+}
+
+function expandPath(value: string, cwd: string): string {
+  const trimmed = value.trim();
+  if (trimmed.startsWith("~/")) return path.join(homedir(), trimmed.slice(2));
+  if (trimmed === "~") return homedir();
+  if (trimmed.startsWith("./") || trimmed === ".") return path.resolve(cwd, trimmed);
+  if (path.isAbsolute(trimmed)) return trimmed;
+  return path.resolve(cwd, trimmed);
+}
+
+function looksLikeManagedClone(rootPath: string): boolean {
+  return existsSync(path.join(rootPath, ".sf-skills-managed"));
+}
+
+/**
+ * Fully synchronous local detection.
+ *
+ * Order of preference:
+ *   1. Global managed clone (most common — `/sf-skills defaults install`)
+ *   2. Project managed clone
+ *   3. Linked user-owned checkout (any scope)
+ *   4. Not installed
+ *
+ * Returns a status whose `freshness` is `"unknown"` when installed (the
+ * deferred refresh fills it in) and `"unknown"` when not installed
+ * (the renderer treats not-installed specially regardless of freshness).
+ */
+export function detectInstallStateLocal(cwd: string): SfSkillsStatusInfo {
+  const globalClone = inspectManagedClone("global");
+  if (globalClone.exists && globalClone.managed && globalClone.wired) {
+    return buildManagedStatus(globalClone.rootPath, globalClone.skillsPath, "global");
+  }
+
+  const projectClone = inspectManagedClone("project", cwd);
+  if (projectClone.exists && projectClone.managed && projectClone.wired) {
+    return buildManagedStatus(projectClone.rootPath, projectClone.skillsPath, "project");
+  }
+
+  const linked = detectLinkedAfvCheckout(cwd);
+  if (linked) {
+    return {
+      installKind: "linked",
+      scope: linked.scope,
+      skillsPath: linked.skillsPath,
+      rootPath: linked.rootPath,
+      localSha: readLocalGitHead(linked.rootPath),
+      skillCount: countSkillsInDir(linked.skillsPath),
+      // Linked checkouts are user-owned working trees — never nag for
+      // updates. Freshness stays "unknown" and the row renders without
+      // the orange "↑ commits behind" suffix.
+      freshness: "unknown",
+      loading: false,
+    };
+  }
+
+  return {
+    installKind: "not-installed",
+    freshness: "unknown",
+    loading: false,
+  };
+}
+
+function buildManagedStatus(
+  rootPath: string,
+  skillsPath: string,
+  scope: "global" | "project",
+): SfSkillsStatusInfo {
+  return {
+    installKind: "managed",
+    scope,
+    skillsPath,
+    rootPath,
+    localSha: readLocalGitHead(rootPath),
+    skillCount: countSkillsInDir(skillsPath),
+    // The remote comparison runs in detectSfSkillsStatus(); local-only
+    // detection leaves this unknown so the row paints "Installed" while
+    // the network probe is in flight.
+    freshness: "unknown",
+    loading: false,
+  };
+}
+
+// -------------------------------------------------------------------------------------------------
+// Upstream comparison (network)
+// -------------------------------------------------------------------------------------------------
+
+/** Hook for tests to stub the GitHub call. */
+export type SfSkillsFetchCompareFn = (
+  localSha: string,
+  signal?: AbortSignal,
+) => Promise<{ remoteSha: string; behindBy: number } | undefined>;
+
+/**
+ * Compare a local SHA against `main` via the GitHub compare endpoint.
+ *
+ * One round-trip gives us both the upstream HEAD SHA and the commit-count
+ * delta. Returns `undefined` on any failure (network down, rate-limit,
+ * malformed payload, unauthenticated 403, …) so the caller degrades to
+ * `freshness: "unknown"` cleanly.
+ *
+ * Anonymous GitHub API rate limit is 60/hour/IP. The cache-first first paint
+ * + 24h cache TTL keeps a busy user well under that ceiling.
+ */
+export async function fetchUpstreamCompare(
+  localSha: string,
+  signal?: AbortSignal,
+): Promise<{ remoteSha: string; behindBy: number } | undefined> {
+  if (!/^[0-9a-f]{7,64}$/.test(localSha)) return undefined;
+  try {
+    const url = `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/compare/${localSha}...${REPO_DEFAULT_BRANCH}`;
+    const timeoutSignal = AbortSignal.timeout(GITHUB_COMPARE_TIMEOUT_MS);
+    const combined = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+    const response = await fetch(url, {
+      signal: combined,
+      headers: {
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+    if (!response.ok) return undefined;
+    const payload = (await response.json()) as {
+      status?: unknown;
+      ahead_by?: unknown;
+      behind_by?: unknown;
+      total_commits?: unknown;
+      base_commit?: { sha?: unknown };
+      merge_base_commit?: { sha?: unknown };
+      commits?: Array<{ sha?: unknown }>;
+    };
+    // Resolve the upstream HEAD SHA. The `compare` endpoint reports the
+    // upstream tip as the last entry of `commits` (the ones the caller is
+    // behind on). When there are zero behind commits, the local SHA is the
+    // upstream HEAD itself.
+    const behindBy = typeof payload.behind_by === "number" ? payload.behind_by : undefined;
+    if (typeof behindBy !== "number") return undefined;
+    let remoteSha: string | undefined;
+    if (behindBy === 0) {
+      remoteSha = localSha;
+    } else if (Array.isArray(payload.commits) && payload.commits.length > 0) {
+      const last = payload.commits[payload.commits.length - 1];
+      if (last && typeof last.sha === "string") remoteSha = last.sha;
+    }
+    if (!remoteSha) return undefined;
+    return { remoteSha, behindBy };
+  } catch {
+    return undefined;
+  }
+}
+
+// -------------------------------------------------------------------------------------------------
+// Public detect
+// -------------------------------------------------------------------------------------------------
+
+/**
+ * Full status: local FS detection plus (when installed) upstream comparison.
+ *
+ * Always resolves; never throws. Returns the input local status verbatim
+ * with `freshness` filled in when the comparison succeeded.
+ */
+export async function detectSfSkillsStatus(
+  cwd: string,
+  fetchCompare: SfSkillsFetchCompareFn = fetchUpstreamCompare,
+): Promise<SfSkillsStatusInfo> {
+  const local = detectInstallStateLocal(cwd);
+  if (local.installKind === "not-installed" || local.installKind === "linked") {
+    // Linked checkouts: don't poke the network — user owns the tree.
+    // Not installed: nothing to compare.
+    return local;
+  }
+  if (!local.localSha) {
+    return { ...local, freshness: "unknown" };
+  }
+
+  const compare = await fetchCompare(local.localSha);
+  if (!compare) {
+    return { ...local, freshness: "unknown" };
+  }
+
+  return {
+    ...local,
+    remoteSha: compare.remoteSha,
+    commitsBehind: compare.behindBy,
+    freshness: compare.behindBy === 0 ? "latest" : "update-available",
+  };
+}

--- a/extensions/sf-welcome/lib/splash-component.ts
+++ b/extensions/sf-welcome/lib/splash-component.ts
@@ -329,6 +329,68 @@ function formatGatewayStatusValue(data: SplashData, mode: GlyphMode): string {
   }
 }
 
+function formatSfSkillsStatusValue(data: SplashData, mode: GlyphMode): string {
+  const skills = data.sfSkills;
+
+  if (!skills || skills.loading || skills.freshness === "checking") {
+    return MUTED(`${glyph("hourglass", mode)} Checking`);
+  }
+
+  // Strong opinionated nudge when the official library isn't installed:
+  // bright orange ↑ + bold action verb. The matching "/sf-skills defaults
+  // install" command is rendered on a muted sub-line below the row (see
+  // buildLeftColumn) so the row text itself stays inside the 72-col
+  // left-column cap that the SALESFORCE wordmark drives.
+  if (skills.installKind === "not-installed") {
+    return `${SF_ORANGE("↑")} ${SF_ORANGE("Install official skills")} ${MUTED("· afv-library")}`;
+  }
+
+  const skillCountSuffix =
+    typeof skills.skillCount === "number" && skills.skillCount > 0
+      ? ` ${MUTED(`(${skills.skillCount} skill${skills.skillCount === 1 ? "" : "s"})`)}`
+      : "";
+
+  if (skills.installKind === "linked") {
+    // User-owned checkout: green ✓, never nag for updates.
+    return `${SF_GREEN("✓")} ${SF_GREEN("afv-library linked")}${skillCountSuffix}`;
+  }
+
+  // installKind === "managed"
+  if (skills.freshness === "update-available") {
+    const behind =
+      typeof skills.commitsBehind === "number" && skills.commitsBehind > 0
+        ? `${skills.commitsBehind} commit${skills.commitsBehind === 1 ? "" : "s"} behind`
+        : "update available";
+    return `${SF_ORANGE("↑")} ${SF_ORANGE("afv-library")} ${MUTED(`· ${behind}`)}`;
+  }
+
+  if (skills.freshness === "latest") {
+    return `${SF_GREEN("✓")} ${SF_GREEN("afv-library installed")} ${MUTED("· latest")}${skillCountSuffix}`;
+  }
+
+  // freshness === "unknown" — we know it's installed; the network probe
+  // either hasn't run yet or failed. Render green to avoid a false alarm.
+  return `${SF_GREEN("✓")} ${SF_GREEN("afv-library installed")}${skillCountSuffix}`;
+}
+
+/** Suggested follow-up command for the current sf-skills state, or null when
+ *  the row is informational only. Rendered as a muted sub-line so it never
+ *  pushes the main row past the column cap.
+ *
+ *  Gated on `loading` so the hint never appears under the "⏳ Checking"
+ *  state — we don't actually know the install state yet, and showing
+ *  "/sf-skills defaults install" before detection completes would be a
+ *  false claim. */
+function sfSkillsActionHint(skills: SplashData["sfSkills"]): string | null {
+  if (!skills) return null;
+  if (skills.loading || skills.freshness === "checking") return null;
+  if (skills.installKind === "not-installed") return "/sf-skills defaults install";
+  if (skills.installKind === "managed" && skills.freshness === "update-available") {
+    return "/sf-skills defaults update";
+  }
+  return null;
+}
+
 function formatSfCliStatusValue(data: SplashData, mode: GlyphMode): string {
   const cli = data.sfCli;
 
@@ -496,6 +558,22 @@ function buildLeftColumn(
     lines.push(
       formatGlyphInfoRow("privacy", mode, "Privacy", formatPrivacyStatusValue(data.privacy)),
     );
+  }
+
+  // SF Skills (forcedotcom/afv-library) install + freshness. Always
+  // rendered — the not-installed state is the loud orange nudge that
+  // pushes users toward the official skills library. Cache-first paint
+  // (see sf-skills-status.ts) keeps this row free at startup.
+  lines.push(
+    formatGlyphInfoRow("sfSkills", mode, "SF Skills", formatSfSkillsStatusValue(data, mode)),
+  );
+  // Action hint as a muted sub-line, same convention the gateway row uses
+  // for its key-conflict warning. Only fires when there's something the
+  // user can actionably run from the row's current state.
+  const sfSkillsHint = sfSkillsActionHint(data.sfSkills);
+  if (sfSkillsHint) {
+    const truncated = truncateToWidth(sfSkillsHint, Math.max(10, colWidth - 4), "…");
+    lines.push(`   ${MUTED(`→ ${truncated}`)}`);
   }
   lines.push("");
 

--- a/extensions/sf-welcome/lib/splash-data.ts
+++ b/extensions/sf-welcome/lib/splash-data.ts
@@ -50,6 +50,9 @@ export type {
   AnnouncementsSummary,
   LoadedCounts,
   SfCliStatusInfo,
+  SfSkillsStatusInfo,
+  SfSkillsInstallKind,
+  SfSkillsFreshness,
   SplashData,
   RecentSession,
   ExtensionHealthItem,
@@ -66,6 +69,13 @@ export {
   readCachedSfCliStatus,
   writeCachedSfCliStatus,
 } from "./sf-cli-status.ts";
+export {
+  detectSfSkillsStatus,
+  detectInstallStateLocal,
+  fetchUpstreamCompare,
+  readCachedSfSkillsStatus,
+  writeCachedSfSkillsStatus,
+} from "./sf-skills-status.ts";
 export { estimateMonthlyCost, getRecentSessions } from "./session-data.ts";
 export {
   buildWhatsNewPayload,

--- a/extensions/sf-welcome/lib/types.ts
+++ b/extensions/sf-welcome/lib/types.ts
@@ -39,6 +39,40 @@ export interface SfCliStatusInfo {
   loading: boolean;
 }
 
+/**
+ * How the official forcedotcom/afv-library skills repo is wired into the
+ * current pi install.
+ *
+ *   managed       — cloned + sentinel-marked by `/sf-skills defaults install`
+ *   linked        — user-owned checkout wired via `/sf-skills defaults link`
+ *   not-installed — no afv-library entry found in either scope
+ */
+export type SfSkillsInstallKind = "managed" | "linked" | "not-installed";
+
+/** Same vocabulary as SfCliFreshness so the splash row reads symmetrically. */
+export type SfSkillsFreshness = "checking" | "latest" | "update-available" | "unknown";
+
+export interface SfSkillsStatusInfo {
+  installKind: SfSkillsInstallKind;
+  /** Scope of the install — "global" or "project". Undefined when not installed. */
+  scope?: "global" | "project";
+  /** Absolute path to the wired skills/ dir. Undefined when not installed. */
+  skillsPath?: string;
+  /** Absolute path to the repo root. Undefined when not installed. */
+  rootPath?: string;
+  /** Local commit SHA (full or abbreviated) read from .git/HEAD. */
+  localSha?: string;
+  /** Latest upstream main commit SHA from GitHub. */
+  remoteSha?: string;
+  /** Number of commits the local clone is behind upstream main, when we
+   *  could compute it via the GitHub compare endpoint. */
+  commitsBehind?: number;
+  /** Number of skill subdirs under <skillsPath>/ (each with a SKILL.md). */
+  skillCount?: number;
+  freshness: SfSkillsFreshness;
+  loading: boolean;
+}
+
 /** Install status shown in the splash's Recommendations block. */
 export type RecommendationDisplayStatus = "installed" | "pending" | "declined";
 
@@ -135,6 +169,10 @@ export interface SplashData {
   recentSessionsLoading?: boolean;
   /** Lightweight SF CLI install/latest status populated asynchronously after initial render. */
   sfCli?: SfCliStatusInfo;
+  /** Lightweight forcedotcom/afv-library install + freshness status
+   *  populated asynchronously after initial render. Mirrors the sfCli
+   *  cache-first → deferred-refresh pattern; never blocks startup. */
+  sfSkills?: SfSkillsStatusInfo;
   /** Short summary of pi-coding-agent changes since the user's last splash.
    * Present only when there is something new to announce. */
   whatsNew?: WhatsNewSummary;

--- a/extensions/sf-welcome/tests/sf-skills-status.test.ts
+++ b/extensions/sf-welcome/tests/sf-skills-status.test.ts
@@ -1,0 +1,359 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/**
+ * Targeted tests for the welcome-screen sf-skills status helper.
+ *
+ * Covers the three layers of detection independently so a regression in any
+ * one of them produces a precise failure message rather than a tangled
+ * "everything broke" surface:
+ *
+ *   1. readLocalGitHead     — pure FS, supports loose + packed refs
+ *   2. countSkillsInDir     — pure FS, counts SKILL.md-bearing dirs
+ *   3. detectLinkedAfvCheckout / detectInstallStateLocal
+ *                           — wires settings.json + sentinel into a single
+ *                             status enum with documented precedence
+ *   4. detectSfSkillsStatus — orchestrates a stubbed compare-API result
+ *
+ * The on-disk cache (read/writeCachedSfSkillsStatus) is exercised end-to-end
+ * via PI_CODING_AGENT_DIR; the canonical state-store lives at
+ *   <agentDir>/sf-pi/sf-welcome/sf-skills-status.json
+ * which is exactly what the splash will read on the next launch.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  countSkillsInDir,
+  detectInstallStateLocal,
+  detectLinkedAfvCheckout,
+  detectSfSkillsStatus,
+  readCachedSfSkillsStatus,
+  readLocalGitHead,
+  writeCachedSfSkillsStatus,
+} from "../lib/sf-skills-status.ts";
+
+const PI_AGENT_ENV = "PI_CODING_AGENT_DIR";
+
+let tmpDir: string;
+let homeDir: string;
+let prevAgent: string | undefined;
+let prevHome: string | undefined;
+
+beforeEach(() => {
+  // PI_CODING_AGENT_DIR sandboxes globalAgentPath() — the managed clone path
+  // and the cache file both live under this dir. HOME sandboxes ~/... in
+  // settings.json so the wired-path check resolves inside the tmp tree
+  // instead of the developer's real home.
+  homeDir = mkdtempSync(path.join(os.tmpdir(), "sf-pi-skills-home-"));
+  tmpDir = path.join(homeDir, ".pi", "agent");
+  mkdirSync(tmpDir, { recursive: true });
+  prevAgent = process.env[PI_AGENT_ENV];
+  prevHome = process.env.HOME;
+  process.env[PI_AGENT_ENV] = tmpDir;
+  process.env.HOME = homeDir;
+});
+
+afterEach(() => {
+  if (prevAgent === undefined) delete process.env[PI_AGENT_ENV];
+  else process.env[PI_AGENT_ENV] = prevAgent;
+  if (prevHome === undefined) delete process.env.HOME;
+  else process.env.HOME = prevHome;
+  try {
+    rmSync(homeDir, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+});
+
+// ---------------------------------------------------------------------------
+// readLocalGitHead
+// ---------------------------------------------------------------------------
+
+describe("readLocalGitHead", () => {
+  it("reads a directly-stored SHA from .git/HEAD (detached HEAD)", () => {
+    const repo = path.join(tmpDir, "repo");
+    mkdirSync(path.join(repo, ".git"), { recursive: true });
+    writeFileSync(path.join(repo, ".git", "HEAD"), "abc1234def567890abc1234def567890abc12345\n");
+    expect(readLocalGitHead(repo)).toBe("abc1234def567890abc1234def567890abc12345");
+  });
+
+  it("resolves a symbolic ref via .git/refs/heads/<branch>", () => {
+    const repo = path.join(tmpDir, "repo");
+    mkdirSync(path.join(repo, ".git", "refs", "heads"), { recursive: true });
+    writeFileSync(path.join(repo, ".git", "HEAD"), "ref: refs/heads/main\n");
+    writeFileSync(
+      path.join(repo, ".git", "refs", "heads", "main"),
+      "deadbeef1234567890deadbeef1234567890dead\n",
+    );
+    expect(readLocalGitHead(repo)).toBe("deadbeef1234567890deadbeef1234567890dead");
+  });
+
+  it("falls back to packed-refs when the loose ref file is missing", () => {
+    const repo = path.join(tmpDir, "repo");
+    mkdirSync(path.join(repo, ".git"), { recursive: true });
+    writeFileSync(path.join(repo, ".git", "HEAD"), "ref: refs/heads/main\n");
+    writeFileSync(
+      path.join(repo, ".git", "packed-refs"),
+      "# pack-refs with: peeled fully-peeled sorted\n" +
+        "feedface1234567890feedface1234567890feed refs/heads/main\n" +
+        "babecafe1234567890babecafe1234567890babe refs/tags/v1\n",
+    );
+    expect(readLocalGitHead(repo)).toBe("feedface1234567890feedface1234567890feed");
+  });
+
+  it("returns undefined when .git/HEAD is missing", () => {
+    expect(readLocalGitHead(path.join(tmpDir, "no-such-repo"))).toBeUndefined();
+  });
+
+  it("returns undefined for a malformed HEAD", () => {
+    const repo = path.join(tmpDir, "bad-repo");
+    mkdirSync(path.join(repo, ".git"), { recursive: true });
+    writeFileSync(path.join(repo, ".git", "HEAD"), "this is not a valid HEAD line\n");
+    expect(readLocalGitHead(repo)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// countSkillsInDir
+// ---------------------------------------------------------------------------
+
+describe("countSkillsInDir", () => {
+  it("counts only direct subdirs that contain SKILL.md", () => {
+    const skillsDir = path.join(tmpDir, "skills");
+    mkdirSync(path.join(skillsDir, "alpha"), { recursive: true });
+    writeFileSync(path.join(skillsDir, "alpha", "SKILL.md"), "# alpha\n");
+    mkdirSync(path.join(skillsDir, "beta"), { recursive: true });
+    writeFileSync(path.join(skillsDir, "beta", "SKILL.md"), "# beta\n");
+    // Subdir without a SKILL.md is ignored.
+    mkdirSync(path.join(skillsDir, "not-a-skill"), { recursive: true });
+    // Top-level file is ignored.
+    writeFileSync(path.join(skillsDir, "README.md"), "");
+    expect(countSkillsInDir(skillsDir)).toBe(2);
+  });
+
+  it("returns undefined when the directory does not exist", () => {
+    expect(countSkillsInDir(path.join(tmpDir, "nope"))).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectLinkedAfvCheckout — picks up user-owned wired checkouts only
+// ---------------------------------------------------------------------------
+
+describe("detectLinkedAfvCheckout", () => {
+  it("returns null when no settings file exists", () => {
+    expect(detectLinkedAfvCheckout(homeDir)).toBeNull();
+  });
+
+  it("returns the linked checkout when wired in global settings", () => {
+    const checkout = path.join(homeDir, "work", "afv-library");
+    mkdirSync(path.join(checkout, ".git"), { recursive: true });
+    mkdirSync(path.join(checkout, "skills"), { recursive: true });
+    writeFileSync(
+      path.join(tmpDir, "settings.json"),
+      JSON.stringify({ skills: [path.join(checkout, "skills")] }),
+    );
+    const result = detectLinkedAfvCheckout(homeDir);
+    expect(result).toEqual({
+      rootPath: checkout,
+      skillsPath: path.join(checkout, "skills"),
+      scope: "global",
+    });
+  });
+
+  it("skips a checkout that carries the .sf-skills-managed sentinel", () => {
+    const checkout = path.join(homeDir, "managed-clone");
+    mkdirSync(path.join(checkout, ".git"), { recursive: true });
+    mkdirSync(path.join(checkout, "skills"), { recursive: true });
+    writeFileSync(path.join(checkout, ".sf-skills-managed"), "managed\n");
+    writeFileSync(
+      path.join(tmpDir, "settings.json"),
+      JSON.stringify({ skills: [path.join(checkout, "skills")] }),
+    );
+    expect(detectLinkedAfvCheckout(homeDir)).toBeNull();
+  });
+
+  it("ignores entries that don't end in /skills", () => {
+    const checkout = path.join(homeDir, "weird-checkout");
+    mkdirSync(path.join(checkout, ".git"), { recursive: true });
+    mkdirSync(path.join(checkout, "skills"), { recursive: true });
+    writeFileSync(path.join(tmpDir, "settings.json"), JSON.stringify({ skills: [checkout] }));
+    expect(detectLinkedAfvCheckout(homeDir)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectInstallStateLocal — precedence: managed-global > managed-project > linked > none
+// ---------------------------------------------------------------------------
+
+describe("detectInstallStateLocal", () => {
+  function createManagedGlobal(): { rootPath: string; skillsPath: string } {
+    const rootPath = path.join(tmpDir, "sf-skills", "afv-library");
+    const skillsPath = path.join(rootPath, "skills");
+    mkdirSync(skillsPath, { recursive: true });
+    mkdirSync(path.join(rootPath, ".git", "refs", "heads"), { recursive: true });
+    writeFileSync(path.join(rootPath, ".git", "HEAD"), "ref: refs/heads/main\n");
+    writeFileSync(
+      path.join(rootPath, ".git", "refs", "heads", "main"),
+      "1111111111111111111111111111111111111111\n",
+    );
+    writeFileSync(path.join(rootPath, ".sf-skills-managed"), "managed\n");
+    // Wire it in the global settings (absolute path so HOME-expansion isn't required).
+    writeFileSync(path.join(tmpDir, "settings.json"), JSON.stringify({ skills: [skillsPath] }));
+    return { rootPath, skillsPath };
+  }
+
+  it("reports managed when the global clone exists, has the sentinel, and is wired", () => {
+    const { rootPath, skillsPath } = createManagedGlobal();
+    const status = detectInstallStateLocal(homeDir);
+    expect(status.installKind).toBe("managed");
+    expect(status.scope).toBe("global");
+    expect(status.rootPath).toBe(rootPath);
+    expect(status.skillsPath).toBe(skillsPath);
+    expect(status.localSha).toBe("1111111111111111111111111111111111111111");
+    expect(status.freshness).toBe("unknown");
+  });
+
+  it("reports linked when only a user-owned checkout is wired", () => {
+    const checkout = path.join(homeDir, "work", "afv-library");
+    mkdirSync(path.join(checkout, ".git"), { recursive: true });
+    mkdirSync(path.join(checkout, "skills", "demo"), { recursive: true });
+    writeFileSync(path.join(checkout, "skills", "demo", "SKILL.md"), "# demo\n");
+    writeFileSync(path.join(checkout, ".git", "HEAD"), "ref: refs/heads/main\n");
+    writeFileSync(
+      path.join(tmpDir, "settings.json"),
+      JSON.stringify({ skills: [path.join(checkout, "skills")] }),
+    );
+    const status = detectInstallStateLocal(homeDir);
+    expect(status.installKind).toBe("linked");
+    expect(status.scope).toBe("global");
+    expect(status.rootPath).toBe(checkout);
+    expect(status.skillCount).toBe(1);
+    // Linked never queries upstream — freshness stays unknown.
+    expect(status.freshness).toBe("unknown");
+  });
+
+  it("reports not-installed when nothing is wired", () => {
+    expect(detectInstallStateLocal(homeDir)).toEqual({
+      installKind: "not-installed",
+      freshness: "unknown",
+      loading: false,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectSfSkillsStatus — wires localSha + fetchCompare
+// ---------------------------------------------------------------------------
+
+describe("detectSfSkillsStatus", () => {
+  function setupManagedGlobal(localSha: string): void {
+    const rootPath = path.join(tmpDir, "sf-skills", "afv-library");
+    const skillsPath = path.join(rootPath, "skills");
+    mkdirSync(skillsPath, { recursive: true });
+    mkdirSync(path.join(rootPath, ".git", "refs", "heads"), { recursive: true });
+    writeFileSync(path.join(rootPath, ".git", "HEAD"), "ref: refs/heads/main\n");
+    writeFileSync(path.join(rootPath, ".git", "refs", "heads", "main"), `${localSha}\n`);
+    writeFileSync(path.join(rootPath, ".sf-skills-managed"), "managed\n");
+    writeFileSync(path.join(tmpDir, "settings.json"), JSON.stringify({ skills: [skillsPath] }));
+  }
+
+  it("reports latest when the compare API returns behind_by=0", async () => {
+    const sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    setupManagedGlobal(sha);
+    const status = await detectSfSkillsStatus(homeDir, async () => ({
+      remoteSha: sha,
+      behindBy: 0,
+    }));
+    expect(status.installKind).toBe("managed");
+    expect(status.freshness).toBe("latest");
+    expect(status.commitsBehind).toBe(0);
+    expect(status.remoteSha).toBe(sha);
+  });
+
+  it("reports update-available with commit count when behind_by>0", async () => {
+    setupManagedGlobal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    const status = await detectSfSkillsStatus(homeDir, async () => ({
+      remoteSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      behindBy: 7,
+    }));
+    expect(status.freshness).toBe("update-available");
+    expect(status.commitsBehind).toBe(7);
+  });
+
+  it("degrades to freshness=unknown when the compare API fails", async () => {
+    setupManagedGlobal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    const status = await detectSfSkillsStatus(homeDir, async () => undefined);
+    expect(status.installKind).toBe("managed");
+    expect(status.freshness).toBe("unknown");
+    expect(status.commitsBehind).toBeUndefined();
+  });
+
+  it("never calls the compare API for a linked checkout", async () => {
+    const checkout = path.join(homeDir, "work", "afv-library");
+    mkdirSync(path.join(checkout, ".git"), { recursive: true });
+    mkdirSync(path.join(checkout, "skills"), { recursive: true });
+    writeFileSync(path.join(checkout, ".git", "HEAD"), "ref: refs/heads/main\n");
+    writeFileSync(
+      path.join(tmpDir, "settings.json"),
+      JSON.stringify({ skills: [path.join(checkout, "skills")] }),
+    );
+    let calls = 0;
+    const status = await detectSfSkillsStatus(homeDir, async () => {
+      calls++;
+      return { remoteSha: "x", behindBy: 99 };
+    });
+    expect(status.installKind).toBe("linked");
+    expect(calls).toBe(0);
+  });
+
+  it("never calls the compare API when not installed", async () => {
+    let calls = 0;
+    const status = await detectSfSkillsStatus(homeDir, async () => {
+      calls++;
+      return { remoteSha: "x", behindBy: 99 };
+    });
+    expect(status.installKind).toBe("not-installed");
+    expect(calls).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// On-disk cache round-trip
+// ---------------------------------------------------------------------------
+
+describe("readCachedSfSkillsStatus / writeCachedSfSkillsStatus", () => {
+  it("round-trips a managed status through the canonical cache file", () => {
+    expect(readCachedSfSkillsStatus()).toBeNull();
+    writeCachedSfSkillsStatus({
+      installKind: "managed",
+      scope: "global",
+      skillsPath: "/tmp/x/skills",
+      rootPath: "/tmp/x",
+      localSha: "abc1234abc1234abc1234abc1234abc1234abcd",
+      remoteSha: "abc1234abc1234abc1234abc1234abc1234abcd",
+      commitsBehind: 0,
+      skillCount: 12,
+      freshness: "latest",
+      loading: false,
+    });
+    const cached = readCachedSfSkillsStatus();
+    expect(cached).toMatchObject({
+      installKind: "managed",
+      freshness: "latest",
+      commitsBehind: 0,
+      skillCount: 12,
+      loading: false,
+    });
+  });
+
+  it("returns null when the cache is older than the requested TTL", () => {
+    writeCachedSfSkillsStatus({
+      installKind: "not-installed",
+      freshness: "unknown",
+      loading: false,
+    });
+    // Negative TTL forces every cached entry to look stale.
+    expect(readCachedSfSkillsStatus(-1)).toBeNull();
+  });
+});

--- a/extensions/sf-welcome/tests/splash-sf-skills.test.ts
+++ b/extensions/sf-welcome/tests/splash-sf-skills.test.ts
@@ -1,0 +1,186 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/**
+ * Render-level checks for the SF Skills splash row.
+ *
+ * Tests the five visual states the row can be in. Strips ANSI before
+ * matching so the assertions describe what the user actually sees, not
+ * the color-code payload. The row label and ↑ glyph are colored at
+ * render time; we verify the text + ASCII glyph here and trust the
+ * existing snapshot/visual tests to cover color regressions.
+ */
+import { describe, expect, it } from "vitest";
+import type { SplashData, SfSkillsStatusInfo } from "../lib/types.ts";
+
+function stripAnsi(s: string): string {
+  return s.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function baseData(sfSkills: SfSkillsStatusInfo | undefined): SplashData {
+  return {
+    modelName: "Claude Sonnet 4",
+    providerName: "anthropic",
+    loadedCounts: { extensions: 5, skills: 2, promptTemplates: 1 },
+    recentSessions: [],
+    extensionHealth: [],
+    slackConnected: false,
+    slackVisible: false,
+    monthlyCost: 0,
+    monthlyBudget: 3000,
+    sfCli: { installed: true, freshness: "latest", loading: false, installedVersion: "2.134.6" },
+    privacy: { telemetryEnabled: false, source: "sf-pi-default" },
+    sfSkills,
+  };
+}
+
+interface RenderedSkillsRow {
+  /** The main row containing the SF Skills label. */
+  row: string;
+  /** Optional muted action sub-line directly under the row, or null. */
+  hint: string | null;
+  /** Full plain-text render, for ad-hoc assertions. */
+  full: string;
+}
+
+async function renderRow(sfSkills: SfSkillsStatusInfo | undefined): Promise<RenderedSkillsRow> {
+  // Force ASCII glyphs so assertions don't depend on emoji width.
+  process.env.SF_PI_ASCII_ICONS = "1";
+  try {
+    const { SfWelcomeOverlay } = await import("../lib/splash-component.ts");
+    const overlay = new SfWelcomeOverlay(baseData(sfSkills));
+    // 220 cols matches the wide-layout smoke tests so the right side of
+    // the row is never column-clipped by the splash's column rules.
+    const lines = overlay.render(220).map(stripAnsi);
+    const idx = lines.findIndex((line) => line.includes("SF Skills"));
+    if (idx === -1) throw new Error(`SF Skills row not found in:\n${lines.join("\n")}`);
+    const next = lines[idx + 1] ?? "";
+    // The hint sub-line uses a leading "→ " inside a muted color block.
+    const hint = next.includes("→") ? next : null;
+    return { row: lines[idx], hint, full: lines.join("\n") };
+  } finally {
+    delete process.env.SF_PI_ASCII_ICONS;
+  }
+}
+
+describe("SF Skills splash row — five render states", () => {
+  it("loading: shows the hourglass while the deferred refresh runs", async () => {
+    const { row, hint } = await renderRow({
+      installKind: "not-installed",
+      freshness: "checking",
+      loading: true,
+    });
+    expect(row).toContain("SF Skills");
+    expect(row).toContain("Checking");
+    // No action hint while the row is still loading — we don't know yet.
+    expect(hint).toBeNull();
+  });
+
+  it("not-installed: opinionated orange ↑ row + muted install-command sub-line", async () => {
+    const { row, hint } = await renderRow({
+      installKind: "not-installed",
+      freshness: "unknown",
+      loading: false,
+    });
+    expect(row).toContain("SF Skills");
+    expect(row).toContain("↑");
+    expect(row).toContain("Install official skills");
+    expect(row).toContain("afv-library");
+    // The actionable command lives on the muted sub-line so the row stays
+    // inside the column-width cap.
+    expect(hint).not.toBeNull();
+    expect(hint).toContain("/sf-skills defaults install");
+  });
+
+  it("managed + latest: green ✓ with skill count and 'latest' suffix, no hint", async () => {
+    const { row, hint } = await renderRow({
+      installKind: "managed",
+      scope: "global",
+      rootPath: "/home/me/.pi/agent/sf-skills/afv-library",
+      skillsPath: "/home/me/.pi/agent/sf-skills/afv-library/skills",
+      localSha: "a".repeat(40),
+      remoteSha: "a".repeat(40),
+      commitsBehind: 0,
+      skillCount: 53,
+      freshness: "latest",
+      loading: false,
+    });
+    expect(row).toContain("✓");
+    expect(row).toContain("afv-library installed");
+    expect(row).toContain("latest");
+    expect(row).toContain("53 skills");
+    // Nothing actionable on this state — no sub-line.
+    expect(hint).toBeNull();
+  });
+
+  it("managed + update-available: orange ↑ row + muted update-command sub-line", async () => {
+    const { row, hint } = await renderRow({
+      installKind: "managed",
+      scope: "global",
+      rootPath: "/home/me/.pi/agent/sf-skills/afv-library",
+      skillsPath: "/home/me/.pi/agent/sf-skills/afv-library/skills",
+      localSha: "a".repeat(40),
+      remoteSha: "b".repeat(40),
+      commitsBehind: 12,
+      freshness: "update-available",
+      loading: false,
+    });
+    expect(row).toContain("↑");
+    expect(row).toContain("afv-library");
+    expect(row).toContain("12 commits behind");
+    expect(hint).not.toBeNull();
+    expect(hint).toContain("/sf-skills defaults update");
+  });
+
+  it("managed + update-available with behind=1: singular 'commit'", async () => {
+    const { row } = await renderRow({
+      installKind: "managed",
+      scope: "global",
+      rootPath: "/home/me/.pi/agent/sf-skills/afv-library",
+      skillsPath: "/home/me/.pi/agent/sf-skills/afv-library/skills",
+      localSha: "a".repeat(40),
+      remoteSha: "b".repeat(40),
+      commitsBehind: 1,
+      freshness: "update-available",
+      loading: false,
+    });
+    expect(row).toContain("1 commit behind");
+    expect(row).not.toContain("1 commits behind");
+  });
+
+  it("linked: green ✓, never nags, no action hint", async () => {
+    const { row, hint } = await renderRow({
+      installKind: "linked",
+      scope: "global",
+      rootPath: "/Users/me/work/afv-library",
+      skillsPath: "/Users/me/work/afv-library/skills",
+      localSha: "c".repeat(40),
+      skillCount: 7,
+      freshness: "unknown",
+      loading: false,
+    });
+    expect(row).toContain("✓");
+    expect(row).toContain("afv-library linked");
+    expect(row).toContain("7 skills");
+    // Linked rows never carry the orange ↑ — they're user-owned working trees.
+    expect(row).not.toContain("↑");
+    expect(row).not.toContain("commits behind");
+    expect(hint).toBeNull();
+  });
+
+  it("managed + unknown freshness: still green ✓ (no false 'update' alarm), no hint", async () => {
+    const { row, hint } = await renderRow({
+      installKind: "managed",
+      scope: "global",
+      rootPath: "/home/me/.pi/agent/sf-skills/afv-library",
+      skillsPath: "/home/me/.pi/agent/sf-skills/afv-library/skills",
+      localSha: "a".repeat(40),
+      skillCount: 53,
+      freshness: "unknown",
+      loading: false,
+    });
+    expect(row).toContain("✓");
+    expect(row).toContain("afv-library installed");
+    expect(row).not.toContain("↑");
+    expect(row).not.toContain("Update");
+    expect(hint).toBeNull();
+  });
+});

--- a/lib/common/glyph-policy.ts
+++ b/lib/common/glyph-policy.ts
@@ -167,6 +167,11 @@ export const GLYPH_TABLE = {
   bug: { emoji: "🐛", ascii: "!" },
   pr: { emoji: "🔀", ascii: "><" },
   privacy: { emoji: "🔒", ascii: "#" },
+  // sf-skills row → official Salesforce afv-library install status. The 📚
+  // emoji literally matches the repo name ("afv-library"); ASCII fallback is
+  // a single ampersand to stay one-cell wide ("&" reads as "and / library"
+  // and is not used by any other glyph in this table).
+  sfSkills: { emoji: "📚", ascii: "&" },
   warn: { emoji: "⚠️", ascii: "!" }, // note: VS16 variation selector
   // Inline bullets that already render fine in Terminal.app but we want a
   // single switchable source of truth for custom renderers.


### PR DESCRIPTION
Adds a new status row to the welcome splash, directly under Privacy:

  📚 SF Skills    ✓ afv-library installed · latest (53 skills)
  📚 SF Skills    ↑ afv-library · 12 commits behind
                  → /sf-skills defaults update
  📚 SF Skills    ✓ afv-library linked (7 skills)
  📚 SF Skills    ↑ Install official skills · afv-library
                  → /sf-skills defaults install
  📚 SF Skills    ⏳ Checking

The row is opinionated: it always renders, and the not-installed state shows a bright orange ↑ nudging users toward the official Salesforce skills library. Actionable commands appear on a muted sub-line so the main row stays inside the splash's 72-col left-column cap (same pattern the gateway row uses for its key-conflict warning).

Startup-time guarantees (mirrors the SF CLI row pattern):

  - First paint is purely local: existsSync() + 24h state-store cache. No git subprocess, no network call.
  - Local commit SHA reads .git/HEAD + .git/refs/heads/<branch> directly so depth-1 clones resolve without spawning git.
  - Background refresh is deferred 2.5s after splash paint, staggered after the SF CLI npm-registry probe so the two probes don't pile up.
  - GitHub compare API call has a 5s AbortSignal.timeout; failure degrades to freshness:'unknown' while keeping the row green.
  - Wrapped in markBootStep('sf-welcome.sf-skills-detect', …) for the existing boot-time profiler.

Reuses inspectManagedClone() from extensions/sf-skills/lib/defaults.ts as the source of truth for the managed clone path so the two extensions can never disagree on where the repo lives.

Tests: 32 new (21 unit + 7 render + idempotency on the round-trip).
Total: 2,116 passing, no regressions, tsc + eslint clean.

## What this PR does

<!-- One or two lines. What changes, and for which extension/area? -->

## Why

<!-- The user-facing problem this solves. Link the issue if there is one. -->

Closes #

## How

<!-- Bullet the key changes. Mention any non-obvious design decisions. -->

-
-

## Checklist

- [ ] I ran `npm run validate` locally
- [ ] I updated the affected extension's `README.md` (if behavior changed)
- [ ] I added or updated tests
- [ ] I regenerated the catalog (`npm run generate-catalog`) if I touched `manifest.json`
- [ ] I added a `CHANGELOG.md` entry under `[Unreleased]`
- [ ] This PR is non-breaking, or I called out the breaking change explicitly above

## Notes for reviewers

<!-- Anything to watch out for — gotchas, follow-up work, screenshots. -->
