### PR TITLE
fix(sf-ohana-spinner): swallow stale-ctx throws from rotation timer

### DIFF
--- a/catalog/index.json
+++ b/catalog/index.json
@@ -558,7 +558,7 @@
     "entry": "extensions/sf-ohana-spinner/index.ts",
     "hasReadme": true,
     "hasTests": true,
-    "srcLoc": 417
+    "srcLoc": 432
   },
   {
     "id": "sf-pi-manager",

--- a/extensions/sf-ohana-spinner/index.ts
+++ b/extensions/sf-ohana-spinner/index.ts
@@ -47,6 +47,11 @@ export default function (pi: ExtensionAPI) {
   let activeSessionGeneration = 0;
   let activeSessionKey: string | null = null;
 
+  /** Pure-number guard — safe to call from a timer with a stale ctx. */
+  function isCurrentGeneration(generation: number): boolean {
+    return generation === activeSessionGeneration;
+  }
+
   function sessionKey(ctx: ExtensionContext): string {
     return `${ctx.sessionManager.getSessionId()}::${ctx.cwd}`;
   }
@@ -63,17 +68,28 @@ export default function (pi: ExtensionAPI) {
    * default working message — otherwise "Working..." paints next to the custom
    * indicator. */
   function applyCalmIndicator(ctx: ExtensionContext, generation: number) {
-    if (!ctx.hasUI || !isActiveSession(ctx, generation)) return;
-    ctx.ui.setWorkingIndicator({ frames: buildCalmFrames(), intervalMs: FRAME_INTERVAL_MS });
-    ctx.ui.setWorkingMessage("");
+    if (!isCurrentGeneration(generation)) return;
+    try {
+      if (!ctx.hasUI || !isActiveSession(ctx, generation)) return;
+      ctx.ui.setWorkingIndicator({ frames: buildCalmFrames(), intervalMs: FRAME_INTERVAL_MS });
+      ctx.ui.setWorkingMessage("");
+    } catch {
+      // Stale ctx; drop the tick. Rethrowing would surface as an unhandled
+      // rejection from setInterval and terminate the host process.
+    }
   }
 
   async function applyOhanaIndicator(ctx: ExtensionContext, generation: number) {
-    if (!ctx.hasUI || !isActiveSession(ctx, generation)) return;
-    const frames = buildRainbowFrames(await pickRandomMessage());
-    if (!ctx.hasUI || !isActiveSession(ctx, generation)) return;
-    ctx.ui.setWorkingIndicator({ frames, intervalMs: FRAME_INTERVAL_MS });
-    ctx.ui.setWorkingMessage("");
+    if (!isCurrentGeneration(generation)) return;
+    try {
+      if (!ctx.hasUI || !isActiveSession(ctx, generation)) return;
+      const frames = buildRainbowFrames(await pickRandomMessage());
+      if (!isCurrentGeneration(generation) || !ctx.hasUI) return;
+      ctx.ui.setWorkingIndicator({ frames, intervalMs: FRAME_INTERVAL_MS });
+      ctx.ui.setWorkingMessage("");
+    } catch {
+      // See applyCalmIndicator.
+    }
   }
 
   pi.on("session_start", async (_event, ctx) => {

--- a/extensions/sf-ohana-spinner/tests/lifecycle.test.ts
+++ b/extensions/sf-ohana-spinner/tests/lifecycle.test.ts
@@ -131,6 +131,50 @@ describe("sf-ohana-spinner waiting-state outcome", () => {
   });
 });
 
+describe("sf-ohana-spinner stale-ctx safety", () => {
+  it("swallows a stale-ctx throw from the rotation timer", async () => {
+    vi.useFakeTimers();
+    try {
+      const cwd = tempCwd();
+      writeScopedOhanaSpinnerSettings(cwd, "project", { mode: "ohana" });
+
+      const handlers = registerExtension();
+      const ctx = createCtx(cwd);
+      await runSessionStart(handlers, ctx);
+
+      const indicatorCallsBeforeStale = ctx.ui.setWorkingIndicator.mock.calls.length;
+
+      // Mimic ExtensionRunner.assertActive throwing after session replacement.
+      const staleError = new Error(
+        "This extension ctx is stale after session replacement or reload.",
+      );
+      Object.defineProperty(ctx, "hasUI", {
+        get() {
+          throw staleError;
+        },
+      });
+      ctx.sessionManager.getSessionId = () => {
+        throw staleError;
+      };
+
+      const rejections: unknown[] = [];
+      const onRejection = (reason: unknown) => rejections.push(reason);
+      process.on("unhandledRejection", onRejection);
+      try {
+        await vi.advanceTimersByTimeAsync(5_000);
+        await Promise.resolve();
+      } finally {
+        process.off("unhandledRejection", onRejection);
+      }
+
+      expect(rejections).toEqual([]);
+      expect(ctx.ui.setWorkingIndicator.mock.calls.length).toBe(indicatorCallsBeforeStale);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
 describe("Ohana visible message outcomes", () => {
   it("keeps every possible visible message short and product/platform-oriented", () => {
     const personSpecificTerms = /\b(founder|co-founder|executive|CEO|CTO)\b/i;


### PR DESCRIPTION
# fix(sf-ohana-spinner): swallow stale-ctx throws from rotation timer

## Summary

The 5s message-rotation `setInterval` captures the session-start `ctx` and reuses it on every tick. After any session replacement — `newSession`, `fork`, `switchSession`, `reload` — that captured ctx is stale. The next tick reads `ctx.hasUI`, which routes through `ExtensionRunner.assertActive` and throws. Because the throw happens inside a `setInterval` callback whose return is ignored, the rejection is unhandled and Node's default `--unhandled-rejections=throw` terminates the process. Pi's alt-screen restore on exit wipes the stderr line, leaving the symptom “pi just closes out, no error log.”

The original guards were `ctx.hasUI || isActiveSession(ctx, ...)`, but both reads go through `assertActive` — so the “stale check” was itself the throwing call and never short-circuited.

## Repro

1. Spawn 2+ background subagents in parallel via the `Agent` tool with `run_in_background: true`.
2. Wait for the last to return.
3. Pi exits silently.

To surface the actual rejection, bypass Node's default kill-on-rejection:

```bash
NODE_OPTIONS='--unhandled-rejections=warn' pi 2> >(tee ~/pi-stderr.log >&2)
```

Stack from a real session (1,296 occurrences in one run, all identical):

```
Error: This extension ctx is stale after session replacement or reload. ...
    at ExtensionRunner.assertActive (.../extensions/runner.js:297:19)
    at get hasUI (.../extensions/runner.js:386:24)
    at applyOhanaIndicator (extensions/sf-ohana-spinner/index.ts:72:14)
    at Timeout._onTimeout (extensions/sf-ohana-spinner/index.ts:99:18)
```

## Fix

1. New `isCurrentGeneration(generation)` helper — pure number compare, never reads ctx, safe as the outermost guard inside a timer callback.
2. Reorder the guards: `generation → ctx.hasUI → isActiveSession`. The two ctx-reading checks now run only after the pure-number guard short-circuits.
3. Wrap the bodies of `applyCalmIndicator` and `applyOhanaIndicator` in `try/catch`. Belt-and-suspenders for the cross-`await` race in `applyOhanaIndicator`, where session replacement could land between the generation check and the next ctx access.

`isActiveSession`, the `setInterval` setup, and the `session_start`/`session_shutdown` handlers are unchanged.

## Tests

Adds one regression test that flips `ctx.hasUI` to throw mid-session, advances the rotation timer past 5s, and asserts no unhandled rejections and no further `setWorkingIndicator` calls. **Fails on the unfixed code with the exact error from the field reports.**

```
$ npx vitest run extensions/sf-ohana-spinner
 Test Files  2 passed (2)
      Tests  8 passed (8)
```

## Risk / blast radius

Limited to error paths that previously crashed the host. Happy-path indicator rotation is unchanged. No public API change. No new dependencies. Catalog regenerated by pre-commit hook (`srcLoc: 417 → 432`).
