### PR TITLE
chore(deps): bump github/codeql-action to 4.36.1

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,13 +43,13 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/analyze@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Split from #320 so the mergeable CodeQL patch can land without the trufflesecurity/trufflehog update that is blocked by license policy.\n\nChanges:\n- Update github/codeql-action init/analyze from v4.36.0 to v4.36.1 using the Dependabot-proposed SHA.\n- Leave trufflesecurity/trufflehog pinned at v3.95.3.