### PR TITLE
fix(gateway): fall back to v2 user usage endpoint

### DIFF
--- a/catalog/index.json
+++ b/catalog/index.json
@@ -707,7 +707,7 @@
     "entry": "extensions/sf-llm-gateway-internal/index.ts",
     "hasReadme": true,
     "hasTests": true,
-    "srcLoc": 12187
+    "srcLoc": 12274
   },
   {
     "id": "sf-lsp",

--- a/extensions/sf-llm-gateway-internal/README.md
+++ b/extensions/sf-llm-gateway-internal/README.md
@@ -234,12 +234,14 @@ suffix such as `/v1` or a model-specific route suffix, the config layer
 canonicalizes it back to the root. Runtime endpoint helpers then derive the
 correct routes: OpenAI-compatible chat/model discovery uses the gateway's `/v1`
 route, Anthropic Messages uses the gateway root because the SDK appends
-`/v1/messages`, and admin calls such as `/user/info` use the gateway root.
+`/v1/messages`, and admin calls such as `/user/info`, `/v2/user/info`,
+and `/key/info` use the gateway root.
 
 ## Zero-cost gateway billing
 
 All models report `cost: 0` because the gateway is pre-paid. Billing is tracked
-separately via the monthly usage endpoint (`/user/info`).
+separately via the monthly usage endpoint (`/user/info`, or
+`/v2/user/info?user_id=...` for scoped keys).
 
 ## Command Surface
 
@@ -296,7 +298,7 @@ such as `tokens`, `onboard`, `open-token`, `import-claude`, `doctor`, `debug`,
 | /command usage-probe --trace | —                                     | Render the per-endpoint trace (timings + status) from the last refresh, plus any active key-conflict warning                                   |
 | /command beta \<name\> on    | —                                     | Toggle beta, re-register provider                                                                                                              |
 | Monthly usage fetch          | cached < 60 s old                     | Use cache                                                                                                                                      |
-| Monthly usage fetch          | stale or forced                       | Fetch from gateway /user/info                                                                                                                  |
+| Monthly usage fetch          | stale or forced                       | Fetch from gateway `/user/info`; fallback to `/v2/user/info?user_id=...` when scoped keys allow only v2.                                       |
 
 ## File Structure
 
@@ -434,7 +436,7 @@ errors, SSO/browser redirects, and `model=v1` routing mistakes.
 ## Usage probe: `/sf-llm-gateway usage-probe`
 
 Run `/sf-llm-gateway usage-probe` after key rotation or when usage
-numbers look surprising. It forces a read-only `/user/info` + `/key/info` refresh,
+numbers look surprising. It forces a read-only user-info + `/key/info` refresh,
 reports the live gateway connection classification, shows monthly/user spend and
 current-key spend separately, and explicitly explains whether the available data
 proves a true lifetime user counter. The welcome splash does not render a Lifetime
@@ -585,10 +587,14 @@ pi-ai's `Object.assign` header merge cannot silently drop it.
 
 **Monthly-usage footer is stale or missing:**
 Usage is cached for 60 seconds and refreshes automatically on every
-`turn_end`; run `/sf-llm-gateway refresh` to force a `/user/info`
-fetch immediately. If you're using sf-welcome or sf-devbar as
-consumers, they read from the shared store in `lib/common/monthly-usage/`
-— the gateway must be registered and have succeeded at least once.
+`turn_end`; run `/sf-llm-gateway refresh` to force a usage probe
+immediately. The extension first tries the historical `/user/info` route;
+when the gateway reports a scoped key that is only allowed to call
+`/v2/user/info`, it derives the current `user_id` from `/key/info` and
+falls back to `/v2/user/info?user_id=...`. If you're using sf-welcome or
+sf-devbar as consumers, they read from the shared store in
+`lib/common/monthly-usage/` — the gateway must be registered and have
+succeeded at least once.
 
 **Old and new gateway keys are confusing status or tests:**
 Saved pi config wins over `SF_LLM_GATEWAY_API_KEY`. If both are set

--- a/extensions/sf-llm-gateway-internal/index.ts
+++ b/extensions/sf-llm-gateway-internal/index.ts
@@ -83,7 +83,7 @@
  *   /command usage-probe        | —                                  | Force read-only usage probe
  *   /command beta <name> on     | —                                  | Toggle beta, re-register provider
  *   Monthly usage fetch         | cached < 60 s old                  | Use cache
- *   Monthly usage fetch         | stale or forced                    | Fetch from gateway /user/info
+ *   Monthly usage fetch         | stale or forced                    | Fetch from gateway /user/info, fallback to /v2/user/info when allow-listed
  *
  * Reader guide:
  * - Start at the extension entry point to see the runtime spine
@@ -1026,8 +1026,8 @@ async function handleUsageProbeCommand(
     "Conclusion:",
     "- /key/info is key-scoped and can reset when keys rotate.",
     monthlyUsage?.budgetResetAt || monthlyUsage?.budgetDuration
-      ? "- /user/info appears user-scoped but budget-windowed, so it is not a lifetime counter."
-      : "- /user/info did not prove a true lifetime user counter.",
+      ? "- The user-info endpoint appears user-scoped but budget-windowed, so it is not a lifetime counter."
+      : "- The user-info endpoint did not prove a true lifetime user counter.",
     "- /user/daily/activity adds per-day granularity including failed_requests (early-warning signal).",
     "- The welcome splash does not show Lifetime Usage unless a true user-lifetime endpoint exists.",
   );

--- a/extensions/sf-llm-gateway-internal/lib/monthly-usage.ts
+++ b/extensions/sf-llm-gateway-internal/lib/monthly-usage.ts
@@ -2,8 +2,9 @@
 /**
  * Monthly usage + per-key + gateway health fetcher.
  *
- * The gateway exposes three complementary endpoints:
- *   - `/user/info`        → monthly budget + spend for the whole user
+ * The gateway exposes three complementary endpoint families:
+ *   - `/user/info` or `/v2/user/info?user_id=...`
+ *                         → monthly budget + spend for the whole user
  *   - `/key/info`         → per-key spend + rpm/tpm limits for *this* API key
  *   - `/health/readiness` → gateway version and last upstream probe time
  *
@@ -116,6 +117,15 @@ class GatewayRequestError extends Error {
     this.name = "GatewayRequestError";
   }
 }
+
+type GatewayKeyInfoWithUserId = GatewayKeyInfo & { userId?: string };
+
+type GatewayUserInfoPayload = {
+  max_budget?: number;
+  spend?: number;
+  budget_reset_at?: string;
+  budget_duration?: string;
+};
 
 /**
  * Recorded per-probe trace context. Local to this module — we expose only
@@ -312,7 +322,7 @@ export async function refreshMonthlyUsage(force: boolean, cwd: string): Promise<
     }
 
     if (attempt.keyResult.status === "fulfilled") {
-      snapshot.keyInfo = attempt.keyResult.value;
+      snapshot.keyInfo = toPublicKeyInfo(attempt.keyResult.value);
     } else {
       snapshot.keyInfoError = formatErrorMessage(attempt.keyResult.reason);
     }
@@ -345,15 +355,63 @@ async function runPrimaryProbes(
   trace: GatewayProbeTraceEntry[],
 ): Promise<{
   usageResult: PromiseSettledResult<GatewayMonthlyUsage>;
-  keyResult: PromiseSettledResult<GatewayKeyInfo>;
+  keyResult: PromiseSettledResult<GatewayKeyInfoWithUserId>;
   healthResult: PromiseSettledResult<GatewayHealth>;
 }> {
-  const [usageResult, keyResult, healthResult] = await Promise.allSettled([
+  let [usageResult, keyResult, healthResult] = await Promise.allSettled([
     tracedProbe("user-info", "/user/info", () => fetchMonthlyUsage(baseUrl, apiKey), trace),
     tracedProbe("key-info", "/key/info", () => fetchKeyInfo(baseUrl, apiKey), trace),
     tracedProbe("health", "/health/readiness", () => fetchHealth(baseUrl, apiKey), trace),
-  ]);
+  ] as const);
+
+  // Some gateway keys are now scoped to `/v2/user/info` instead of the
+  // historical `/user/info`. `/key/info` carries the current user id, so when
+  // the legacy route is explicitly not allow-listed we can recover without a
+  // second credential source or a user-visible stale footer.
+  if (shouldTryV2UserInfoFallback(usageResult, keyResult)) {
+    usageResult = await settle(
+      tracedProbe(
+        "user-info",
+        "/v2/user/info?user_id=<current-user>",
+        () => fetchMonthlyUsageV2(baseUrl, apiKey, keyResult.value.userId!),
+        trace,
+      ),
+    );
+  }
+
   return { usageResult, keyResult, healthResult };
+}
+
+async function settle<T>(promise: Promise<T>): Promise<PromiseSettledResult<T>> {
+  try {
+    return { status: "fulfilled", value: await promise };
+  } catch (reason) {
+    return { status: "rejected", reason };
+  }
+}
+
+function shouldTryV2UserInfoFallback(
+  usageResult: PromiseSettledResult<GatewayMonthlyUsage>,
+  keyResult: PromiseSettledResult<GatewayKeyInfoWithUserId>,
+): keyResult is PromiseFulfilledResult<GatewayKeyInfoWithUserId> {
+  if (usageResult.status === "fulfilled" || keyResult.status !== "fulfilled") return false;
+  if (!keyResult.value.userId) return false;
+  const reason = usageResult.reason;
+  if (!(reason instanceof GatewayRequestError)) return false;
+  if (reason.status !== 403 && reason.status !== 404) return false;
+  return /\/v2\/user\/info|not allowed to call this route/i.test(
+    `${reason.bodyPreview}\n${reason.message}`,
+  );
+}
+
+function toPublicKeyInfo(keyInfo: GatewayKeyInfoWithUserId): GatewayKeyInfo {
+  return {
+    spend: keyInfo.spend,
+    rpmLimit: keyInfo.rpmLimit,
+    tpmLimit: keyInfo.tpmLimit,
+    keyName: keyInfo.keyName,
+    fetchedAt: keyInfo.fetchedAt,
+  };
 }
 
 function delay(ms: number): Promise<void> {
@@ -649,31 +707,70 @@ async function fetchMonthlyUsage(baseUrl: string, apiKey: string): Promise<Gatew
     throw await gatewayRequestError("Monthly usage", "user-info", response);
   }
 
-  const json = (await response.json()) as {
-    user_info?: {
-      max_budget?: number;
-      spend?: number;
-      budget_reset_at?: string;
-      budget_duration?: string;
-    };
-  };
-
-  const info = json.user_info;
-  if (!info || typeof info.max_budget !== "number" || typeof info.spend !== "number") {
+  const json = await response.json();
+  const info = parseUserInfoPayload(json, "legacy");
+  if (!info) {
     throw new Error("Monthly usage response is missing required fields.");
   }
 
+  return monthlyUsageFromPayload(info);
+}
+
+async function fetchMonthlyUsageV2(
+  baseUrl: string,
+  apiKey: string,
+  userId: string,
+): Promise<GatewayMonthlyUsage> {
+  const url = new URL(`${toGatewayRootBaseUrl(baseUrl)}/v2/user/info`);
+  url.searchParams.set("user_id", userId);
+  const response = await fetchWithTimeout(
+    url.toString(),
+    {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+    },
+    FETCH_TIMEOUT_MS,
+  );
+
+  if (!response.ok) {
+    throw await gatewayRequestError("Monthly usage v2", "user-info", response);
+  }
+
+  const json = await response.json();
+  const info = parseUserInfoPayload(json, "v2");
+  if (!info) {
+    throw new Error("Monthly usage v2 response is missing required fields.");
+  }
+
+  return monthlyUsageFromPayload(info);
+}
+
+function parseUserInfoPayload(raw: unknown, shape: "legacy" | "v2"): GatewayUserInfoPayload | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const record = raw as Record<string, unknown>;
+  const candidate = shape === "legacy" ? record.user_info : record;
+  if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return null;
+  const info = candidate as GatewayUserInfoPayload;
+  return typeof info.max_budget === "number" && typeof info.spend === "number" ? info : null;
+}
+
+function monthlyUsageFromPayload(info: GatewayUserInfoPayload): GatewayMonthlyUsage {
+  const maxBudget = info.max_budget!;
+  const spend = info.spend!;
   return {
-    maxBudget: info.max_budget,
-    spend: info.spend,
-    remaining: info.max_budget - info.spend,
+    maxBudget,
+    spend,
+    remaining: maxBudget - spend,
     budgetResetAt: info.budget_reset_at ?? "",
     budgetDuration: info.budget_duration ?? "",
     fetchedAt: new Date().toISOString(),
   };
 }
 
-async function fetchKeyInfo(baseUrl: string, apiKey: string): Promise<GatewayKeyInfo> {
+async function fetchKeyInfo(baseUrl: string, apiKey: string): Promise<GatewayKeyInfoWithUserId> {
   const response = await fetchWithTimeout(
     `${toGatewayRootBaseUrl(baseUrl)}/key/info`,
     {
@@ -696,6 +793,7 @@ async function fetchKeyInfo(baseUrl: string, apiKey: string): Promise<GatewayKey
       rpm_limit?: number | null;
       tpm_limit?: number | null;
       key_name?: string | null;
+      user_id?: string | null;
     };
   };
 
@@ -710,6 +808,7 @@ async function fetchKeyInfo(baseUrl: string, apiKey: string): Promise<GatewayKey
     tpmLimit: typeof info.tpm_limit === "number" ? info.tpm_limit : undefined,
     keyName: typeof info.key_name === "string" ? info.key_name : undefined,
     fetchedAt: new Date().toISOString(),
+    userId: typeof info.user_id === "string" && info.user_id.trim() ? info.user_id : undefined,
   };
 }
 

--- a/extensions/sf-llm-gateway-internal/tests/monthly-usage.test.ts
+++ b/extensions/sf-llm-gateway-internal/tests/monthly-usage.test.ts
@@ -90,6 +90,70 @@ describe("gateway monthly usage refresh", () => {
     }
   });
 
+  it("falls back to v2 user-info when the legacy user-info route is not allow-listed", async () => {
+    process.env[BASE_URL_ENV] = "https://gateway.example.test";
+    process.env[API_KEY_ENV] = "test-key";
+    const calls: string[] = [];
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      calls.push(url);
+      if (url.endsWith("/user/info")) {
+        return jsonResponse(403, {
+          detail:
+            "Virtual key is not allowed to call this route. Only allowed to call routes: ['llm_api_routes', '/v2/user/info', '/key/info']. Tried to call route: /user/info",
+        });
+      }
+      if (url.endsWith("/key/info")) {
+        return jsonResponse(200, {
+          info: {
+            spend: 72.88,
+            key_name: "sk-...test",
+            rpm_limit: 100,
+            user_id: "john.hill@salesforce.com",
+          },
+        });
+      }
+      if (url.endsWith("/health/readiness")) return jsonResponse(200, { status: "connected" });
+      if (url.includes("/v2/user/info")) {
+        expect(new URL(url).searchParams.get("user_id")).toBe("john.hill@salesforce.com");
+        return jsonResponse(200, {
+          user_id: "john.hill@salesforce.com",
+          spend: 158.17,
+          max_budget: 50000,
+          budget_duration: "1mo",
+          budget_reset_at: "2026-08-01T00:00:00Z",
+        });
+      }
+      return jsonResponse(404, { error: "not found" });
+    }) as typeof fetch;
+    const unregister = registerGatewayMonthlyUsageRefresher();
+    const cwd = createProjectConfig({
+      baseUrl: "https://gateway.example.test",
+      apiKey: "test-key",
+    });
+
+    try {
+      await getMonthlyUsageStateRefresh(true, cwd);
+
+      const snapshot = getMonthlyUsageState();
+      expect(snapshot.connectionStatus).toMatchObject({ kind: "connected", source: "user-info" });
+      expect(snapshot.monthlyUsageError).toBeNull();
+      expect(snapshot.monthlyUsage).toMatchObject({
+        spend: 158.17,
+        maxBudget: 50000,
+        budgetResetAt: "2026-08-01T00:00:00Z",
+      });
+      expect(snapshot.keyInfo).toMatchObject({ spend: 72.88, keyName: "sk-...test" });
+      expect(snapshot.keyInfo).not.toHaveProperty("userId");
+      expect(calls.some((url) => url.includes("/v2/user/info"))).toBe(true);
+      expect(snapshot.lastProbeTrace?.entries.map((entry) => entry.path)).toContain(
+        "/v2/user/info?user_id=<current-user>",
+      );
+    } finally {
+      unregister();
+    }
+  });
+
   it("preserves last-known monthly usage when a later probe fails", async () => {
     process.env[BASE_URL_ENV] = "https://gateway.example.test";
     process.env[API_KEY_ENV] = "test-key";
@@ -590,7 +654,13 @@ function mockGatewayFetch(options: {
         options.keyStatus === 401 && options.authBody
           ? options.authBody
           : {
-              info: { spend: 7, key_name: "sk-...test", rpm_limit: 100, tpm_limit: 1000 },
+              info: {
+                spend: 7,
+                key_name: "sk-...test",
+                rpm_limit: 100,
+                tpm_limit: 1000,
+                user_id: "test-user@example.com",
+              },
             },
       );
     }


### PR DESCRIPTION
## Summary

Fixes the `sf-llm-gateway-internal` monthly usage/statusline stale state for scoped gateway keys.

Some virtual keys are now allowed to call `/v2/user/info` and `/key/info`, but not the historical `/user/info` endpoint. The extension was treating that 403 as a monthly usage failure and rendering stale cached usage even though current user usage was available.

This PR:

- keeps the existing `/user/info` probe for backward compatibility
- reads `info.user_id` from `/key/info`
- falls back to `/v2/user/info?user_id=<current-user>` when the legacy route is not allow-listed
- parses both legacy nested and v2 flat user-info response shapes
- avoids publishing the internal `userId` helper field in shared key info state/cache
- adds a regression test for the scoped-key allowlist behavior
- updates README/status wording for the v2 fallback

Fixes #478.

## Validation

- Live endpoint probe with the scoped key:
  - `/user/info` → 403
  - `/key/info` → 200 with `info.user_id`
  - `/v2/user/info?user_id=<current-user>` → 200 with current spend/budget
- Verified in Pi after reload: stale footer cleared and current spend rendered.
- Local Salesforce Code Analyzer auto-scan clean:
  - Tool: Local Salesforce Code Analyzer CLI
  - Engine: `eslint:Recommended`
  - Targets: 3 changed files

## Not run

- `npm test -- extensions/sf-llm-gateway-internal/tests/monthly-usage.test.ts`
- `npm run check`

The local checkout is missing test/typecheck binaries (`vitest` and `tsc` are not installed in `node_modules/.bin`).
