### PR TITLE
fix(sf-herdr): detect active Herdr pane for any truthy HERDR_ENV

### DIFF
--- a/extensions/sf-herdr/lib/status.ts
+++ b/extensions/sf-herdr/lib/status.ts
@@ -14,10 +14,15 @@ export interface HerdrRuntimeStatus {
 }
 
 export function getHerdrRuntimeStatus(env: NodeJS.ProcessEnv = process.env): HerdrRuntimeStatus {
+  // Mirror upstream @ogulcancelik/pi-herdr, which activates on any truthy
+  // HERDR_ENV plus a present HERDR_PANE_ID. Requiring the literal "1" here
+  // caused live panes to be reported as "not detected" whenever the herdr
+  // runtime set HERDR_ENV to a non-"1" value.
+  const herdrEnvActive = !!env.HERDR_ENV && !!env.HERDR_PANE_ID;
   return {
-    inHerdrPane: env.HERDR_ENV === "1" && !!env.HERDR_PANE_ID,
-    activeControlEnv: env.HERDR_ENV === "1" && !!env.HERDR_PANE_ID,
-    passiveStatusBridge: env.HERDR_ENV === "1" && !!env.HERDR_SOCKET_PATH && !!env.HERDR_PANE_ID,
+    inHerdrPane: herdrEnvActive,
+    activeControlEnv: herdrEnvActive,
+    passiveStatusBridge: herdrEnvActive && !!env.HERDR_SOCKET_PATH,
     paneId: env.HERDR_PANE_ID,
   };
 }

--- a/extensions/sf-herdr/tests/runtime-status.test.ts
+++ b/extensions/sf-herdr/tests/runtime-status.test.ts
@@ -1,0 +1,47 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/** Runtime detection tests for sf-herdr Herdr-pane environment sensing. */
+import { describe, expect, it } from "vitest";
+import { getHerdrRuntimeStatus } from "../lib/status.ts";
+
+describe("getHerdrRuntimeStatus", () => {
+  it("detects an active Herdr pane when HERDR_ENV is the literal \"1\"", () => {
+    const status = getHerdrRuntimeStatus({ HERDR_ENV: "1", HERDR_PANE_ID: "pane-1" } as NodeJS.ProcessEnv);
+    expect(status.inHerdrPane).toBe(true);
+    expect(status.activeControlEnv).toBe(true);
+    expect(status.paneId).toBe("pane-1");
+  });
+
+  it("detects an active Herdr pane for any truthy HERDR_ENV value (upstream semantics)", () => {
+    for (const value of ["true", "on", "yes", "/tmp/herdr.sock"]) {
+      const status = getHerdrRuntimeStatus({
+        HERDR_ENV: value,
+        HERDR_PANE_ID: "pane-2",
+      } as NodeJS.ProcessEnv);
+      expect(status.inHerdrPane, `HERDR_ENV=${value}`).toBe(true);
+      expect(status.activeControlEnv, `HERDR_ENV=${value}`).toBe(true);
+    }
+  });
+
+  it("reports the passive status bridge only when a socket path is present", () => {
+    const withoutSocket = getHerdrRuntimeStatus({
+      HERDR_ENV: "1",
+      HERDR_PANE_ID: "pane-3",
+    } as NodeJS.ProcessEnv);
+    expect(withoutSocket.passiveStatusBridge).toBe(false);
+
+    const withSocket = getHerdrRuntimeStatus({
+      HERDR_ENV: "1",
+      HERDR_PANE_ID: "pane-3",
+      HERDR_SOCKET_PATH: "/tmp/herdr.sock",
+    } as NodeJS.ProcessEnv);
+    expect(withSocket.passiveStatusBridge).toBe(true);
+  });
+
+  it("is inactive without a pane id or without HERDR_ENV", () => {
+    expect(getHerdrRuntimeStatus({ HERDR_ENV: "1" } as NodeJS.ProcessEnv).inHerdrPane).toBe(false);
+    expect(getHerdrRuntimeStatus({ HERDR_PANE_ID: "pane-4" } as NodeJS.ProcessEnv).inHerdrPane).toBe(
+      false,
+    );
+    expect(getHerdrRuntimeStatus({} as NodeJS.ProcessEnv).inHerdrPane).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes `sf-herdr` reporting **"Herdr pane environment not detected"** while running inside a live, active Herdr pane.

## Root cause
`getHerdrRuntimeStatus` (`extensions/sf-herdr/lib/status.ts`) required `env.HERDR_ENV === "1"` exactly. The upstream `@ogulcancelik/pi-herdr` package activates on **any truthy** `HERDR_ENV` plus a present `HERDR_PANE_ID`:

```js
const herdrEnv = process.env.HERDR_ENV;
const currentPaneTargetEnv = process.env.HERDR_PANE_ID;
if (!herdrEnv || !currentPaneTargetEnv) return;
```

When the herdr runtime set `HERDR_ENV` to a non-`"1"` value, upstream herdr treated the pane as active while `sf-herdr` reported it as not detected — surfacing the misleading advisory in `sf_herdr_plan` output and `/sf-herdr status`/`doctor`.

## Change
- Align detection with upstream semantics: `!!env.HERDR_ENV && !!env.HERDR_PANE_ID`.
- Keep the passive status bridge gated on `HERDR_SOCKET_PATH`.
- Add `tests/runtime-status.test.ts` covering literal `"1"`, other truthy values, the socket-bridge gate, and inactive cases.

## Testing
- Logic validated against the four env permutations.
- Salesforce Code Analyzer auto-scan (eslint:Recommended) on both changed files: **clean**.

Note: no behavior change when `HERDR_ENV` is genuinely unset or `HERDR_PANE_ID` is missing.
