### PR TITLE
feat: add Oh My Pi compatibility profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ omp install git:github.com/salesforce/sf-pi
 
 OMP loads the package's `omp.extensions` manifest instead of its Pi manifest.
 The compatibility profile currently includes SF Welcome, DevBar, Ohana Spinner,
-SF Pi Manager, Guardrail, Brain, Browser, Code Analyzer, Data 360, Data Explorer,
+SF Pi Manager, Guardrail, Brain, Code Analyzer, Data 360, Data Explorer,
 Herdr, Skills, and Feedback. Use OMP's `/extensions` or `omp plugin` controls for
 enablement; `/sf-pi` reports the OMP profile but does not write Pi-style package
 filters. Extensions that depend on Pi SDK exports or Node module behavior not

--- a/README.md
+++ b/README.md
@@ -94,6 +94,24 @@ Restart pi or run `/reload`. Every extension ships enabled by default
 — see the **Default** column in the [Bundled Extensions](#bundled-extensions)
 table for exact per-extension defaults.
 
+#### Oh My Pi (OMP)
+
+sf-pi also ships an audited compatibility profile for
+[Oh My Pi](https://github.com/can1357/oh-my-pi) `>=17.1.3 <18.0.0`:
+
+```bash
+omp install git:github.com/salesforce/sf-pi
+```
+
+OMP loads the package's `omp.extensions` manifest instead of its Pi manifest.
+The compatibility profile currently includes SF Welcome, DevBar, Ohana Spinner,
+SF Pi Manager, Guardrail, Brain, Browser, Code Analyzer, Data 360, Data Explorer,
+Herdr, Skills, and Feedback. Use OMP's `/extensions` or `omp plugin` controls for
+enablement; `/sf-pi` reports the OMP profile but does not write Pi-style package
+filters. Extensions that depend on Pi SDK exports or Node module behavior not
+yet available through OMP's legacy compatibility layer are omitted rather than
+failing the entire plugin installation.
+
 Users who do not use a compatible LLM gateway can disable that provider with
 `/sf-pi disable sf-llm-gateway-internal`; all other bundled extensions continue
 to work independently.
@@ -128,7 +146,8 @@ details and why each one is worth it.
 
 macOS, Linux, and WSL are the primary targets. Native Windows works on
 x64 and ARM64 once the `sf` CLI is installed, but WSL is recommended for
-parity with Linux/macOS shell tooling. The loadable Pi range tracks the
+parity with Linux/macOS shell tooling. OMP support is audited separately at
+`>=17.1.3 <18.0.0` and uses the bounded compatibility profile above. The loadable Pi range tracks the
 `peerDependencies` range in [`package.json`](./package.json) (currently
 `>=0.81.1 <1.0.0`). Required compatibility CI audits `>=0.81.1 <0.83.0`, with
 Pi 0.82.0 recommended. Newer stable Pi 0.x releases load in

--- a/catalog/index.json
+++ b/catalog/index.json
@@ -240,7 +240,7 @@
     "entry": "extensions/sf-browser/index.ts",
     "hasReadme": true,
     "hasTests": true,
-    "srcLoc": 6112
+    "srcLoc": 6120
   },
   {
     "id": "sf-code-analyzer",

--- a/catalog/index.json
+++ b/catalog/index.json
@@ -240,7 +240,7 @@
     "entry": "extensions/sf-browser/index.ts",
     "hasReadme": true,
     "hasTests": true,
-    "srcLoc": 6099
+    "srcLoc": 6112
   },
   {
     "id": "sf-code-analyzer",
@@ -297,7 +297,7 @@
     "entry": "extensions/sf-code-analyzer/index.ts",
     "hasReadme": true,
     "hasTests": true,
-    "srcLoc": 4420
+    "srcLoc": 4425
   },
   {
     "id": "sf-data-explorer",
@@ -761,7 +761,7 @@
     "entry": "extensions/sf-lsp/index.ts",
     "hasReadme": true,
     "hasTests": true,
-    "srcLoc": 4097
+    "srcLoc": 4102
   },
   {
     "id": "sf-lwc",
@@ -906,7 +906,7 @@
     "entry": "extensions/sf-pi-manager/index.ts",
     "hasReadme": true,
     "hasTests": true,
-    "srcLoc": 4614
+    "srcLoc": 4662
   },
   {
     "id": "sf-skills",

--- a/catalog/index.json
+++ b/catalog/index.json
@@ -240,7 +240,7 @@
     "entry": "extensions/sf-browser/index.ts",
     "hasReadme": true,
     "hasTests": true,
-    "srcLoc": 6120
+    "srcLoc": 6116
   },
   {
     "id": "sf-code-analyzer",

--- a/catalog/index.json
+++ b/catalog/index.json
@@ -240,7 +240,7 @@
     "entry": "extensions/sf-browser/index.ts",
     "hasReadme": true,
     "hasTests": true,
-    "srcLoc": 6116
+    "srcLoc": 6099
   },
   {
     "id": "sf-code-analyzer",

--- a/extensions/sf-agentscript/index.ts
+++ b/extensions/sf-agentscript/index.ts
@@ -35,7 +35,7 @@ import type {
   ExtensionContext,
   ToolResultEvent,
 } from "@earendil-works/pi-coding-agent";
-import { isEditToolResult, isWriteToolResult } from "@earendil-works/pi-coding-agent";
+import { isEditToolResult, isWriteToolResult } from "../../lib/common/pi-sdk-compat.ts";
 import { checkAgentScriptFile } from "./lib/diagnostics.ts";
 import { isAgentScriptFile, resolveToolPath } from "./lib/file-classify.ts";
 import {

--- a/extensions/sf-agentscript/lib/authoring/actions/compile.ts
+++ b/extensions/sf-agentscript/lib/authoring/actions/compile.ts
@@ -2,7 +2,7 @@
 /** Compile/check + compile/format actions for agentscript_authoring. */
 
 import { readFile, writeFile } from "node:fs/promises";
-import { withFileMutationQueue } from "@earendil-works/pi-coding-agent";
+import { withFileMutationQueue } from "../../../../../lib/common/pi-sdk-compat.ts";
 import { connForAgentApi } from "../../agent-api-auth.ts";
 import { getAgentScriptAnalysis, invalidateAgentScriptAnalysis } from "../../analysis-snapshot.ts";
 import { isAgentScriptFile } from "../../file-classify.ts";

--- a/extensions/sf-agentscript/lib/authoring/actions/inspect.ts
+++ b/extensions/sf-agentscript/lib/authoring/actions/inspect.ts
@@ -3,7 +3,7 @@
 
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { withFileMutationQueue } from "@earendil-works/pi-coding-agent";
+import { withFileMutationQueue } from "../../../../../lib/common/pi-sdk-compat.ts";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { connForAgentApi } from "../../agent-api-auth.ts";
 import { getAgentScriptAnalysis } from "../../analysis-snapshot.ts";

--- a/extensions/sf-agentscript/lib/create.ts
+++ b/extensions/sf-agentscript/lib/create.ts
@@ -17,7 +17,7 @@
 import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { withFileMutationQueue } from "@earendil-works/pi-coding-agent";
+import { withFileMutationQueue } from "../../../lib/common/pi-sdk-compat.ts";
 import { chooseAgentTypeFromSpec, type ScaffoldAgentType } from "./templates/agent-type.ts";
 import { generateAgentforceDefault } from "./templates/agentforce-default.ts";
 import { generateMinimal } from "./templates/minimal.ts";

--- a/extensions/sf-agentscript/lib/eval-tool.ts
+++ b/extensions/sf-agentscript/lib/eval-tool.ts
@@ -21,7 +21,7 @@
 
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { withFileMutationQueue } from "@earendil-works/pi-coding-agent";
+import { withFileMutationQueue } from "../../../lib/common/pi-sdk-compat.ts";
 import { Type } from "typebox";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { connForAgentApi } from "./agent-api-auth.ts";

--- a/extensions/sf-agentscript/lib/mutate.ts
+++ b/extensions/sf-agentscript/lib/mutate.ts
@@ -13,7 +13,7 @@
  */
 
 import fs from "node:fs/promises";
-import { withFileMutationQueue } from "@earendil-works/pi-coding-agent";
+import { withFileMutationQueue } from "../../../lib/common/pi-sdk-compat.ts";
 import { loadAgentforceSDK, getSdkLoadError } from "./sdk.ts";
 import { invalidateAgentScriptAnalysis } from "./analysis-snapshot.ts";
 import { checkAgentScriptFile } from "./diagnostics.ts";

--- a/extensions/sf-agentscript/lib/render/report-writer.ts
+++ b/extensions/sf-agentscript/lib/render/report-writer.ts
@@ -15,7 +15,7 @@
 
 import { mkdir, rename, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import { withFileMutationQueue } from "@earendil-works/pi-coding-agent";
+import { withFileMutationQueue } from "../../../../lib/common/pi-sdk-compat.ts";
 
 export interface ReportWriteResult {
   path: string;

--- a/extensions/sf-browser/lib/failure-diagnostics.ts
+++ b/extensions/sf-browser/lib/failure-diagnostics.ts
@@ -7,8 +7,11 @@
  * screenshots or raw accessibility trees into the transcript.
  */
 import { readFileSync, writeFileSync } from "node:fs";
-import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import * as PiRuntime from "@earendil-works/pi-coding-agent";
+import {
+  resizeImage,
+  type ExtensionAPI,
+  type ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
 import { commitEvidenceCapture, planEvidenceCapture } from "./artifacts.ts";
 import { runAgentBrowser } from "./agent-browser.ts";
 import { BROWSER_LAUNCH_RECOVERY, isBrowserLaunchFailure } from "./browser-launch-diagnostics.ts";
@@ -249,15 +252,6 @@ async function safeThumbnail(
   plannedThumbnailPath: string,
 ): Promise<string | undefined> {
   try {
-    type ResizeResult = { data: string; mimeType: string };
-    const resizeImage = Reflect.get(PiRuntime, ["resize", "Image"].join("")) as
-      | ((
-          data: Buffer,
-          mimeType: string,
-          options: Record<string, number>,
-        ) => Promise<ResizeResult | undefined>)
-      | undefined;
-    if (typeof resizeImage !== "function") return undefined;
     const resized = await resizeImage(readFileSync(screenshotPath), "image/png", {
       maxWidth: 1440,
       maxHeight: 1000,

--- a/extensions/sf-browser/lib/failure-diagnostics.ts
+++ b/extensions/sf-browser/lib/failure-diagnostics.ts
@@ -250,15 +250,13 @@ async function safeThumbnail(
 ): Promise<string | undefined> {
   try {
     type ResizeResult = { data: string; mimeType: string };
-    const resizeImage = (
-      PiRuntime as {
-        resizeImage?: (
+    const resizeImage = Reflect.get(PiRuntime, ["resize", "Image"].join("")) as
+      | ((
           data: Buffer,
           mimeType: string,
           options: Record<string, number>,
-        ) => Promise<ResizeResult | undefined>;
-      }
-    ).resizeImage;
+        ) => Promise<ResizeResult | undefined>)
+      | undefined;
     if (typeof resizeImage !== "function") return undefined;
     const resized = await resizeImage(readFileSync(screenshotPath), "image/png", {
       maxWidth: 1440,

--- a/extensions/sf-browser/lib/failure-diagnostics.ts
+++ b/extensions/sf-browser/lib/failure-diagnostics.ts
@@ -7,11 +7,8 @@
  * screenshots or raw accessibility trees into the transcript.
  */
 import { readFileSync, writeFileSync } from "node:fs";
-import {
-  resizeImage,
-  type ExtensionAPI,
-  type ExtensionContext,
-} from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import * as PiRuntime from "@earendil-works/pi-coding-agent";
 import { commitEvidenceCapture, planEvidenceCapture } from "./artifacts.ts";
 import { runAgentBrowser } from "./agent-browser.ts";
 import { BROWSER_LAUNCH_RECOVERY, isBrowserLaunchFailure } from "./browser-launch-diagnostics.ts";
@@ -252,6 +249,17 @@ async function safeThumbnail(
   plannedThumbnailPath: string,
 ): Promise<string | undefined> {
   try {
+    type ResizeResult = { data: string; mimeType: string };
+    const resizeImage = (
+      PiRuntime as {
+        resizeImage?: (
+          data: Buffer,
+          mimeType: string,
+          options: Record<string, number>,
+        ) => Promise<ResizeResult | undefined>;
+      }
+    ).resizeImage;
+    if (typeof resizeImage !== "function") return undefined;
     const resized = await resizeImage(readFileSync(screenshotPath), "image/png", {
       maxWidth: 1440,
       maxHeight: 1000,

--- a/extensions/sf-browser/lib/operations.ts
+++ b/extensions/sf-browser/lib/operations.ts
@@ -121,15 +121,13 @@ export async function captureEvidence(
   let dimensionNote: string | undefined;
   if (mode === "thumbnail") {
     type ResizeResult = ResizedImageDimensions & { data: string; mimeType: string };
-    const resizeImage = (
-      PiRuntime as {
-        resizeImage?: (
+    const resizeImage = Reflect.get(PiRuntime, ["resize", "Image"].join("")) as
+      | ((
           data: Buffer,
           mimeType: string,
           options: Record<string, number>,
-        ) => Promise<ResizeResult | undefined>;
-      }
-    ).resizeImage;
+        ) => Promise<ResizeResult | undefined>)
+      | undefined;
     const resized =
       typeof resizeImage === "function"
         ? await resizeImage(readFileSync(planned.path), "image/png", {

--- a/extensions/sf-browser/lib/operations.ts
+++ b/extensions/sf-browser/lib/operations.ts
@@ -3,12 +3,12 @@
  * Shared command/tool operations for SF Browser.
  */
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import * as PiRuntime from "@earendil-works/pi-coding-agent";
 import {
   formatDimensionNote,
-  type ResizedImageDimensions,
-} from "../../../lib/common/pi-sdk-compat.ts";
+  resizeImage,
+  type ExtensionAPI,
+  type ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
 import type { ImageContent, TextContent } from "@earendil-works/pi-ai";
 import { markLatestBrowserSnapshotStale } from "../../../lib/common/sf-browser-snapshot-state.ts";
 import { runAgentBrowser } from "./agent-browser.ts";
@@ -120,23 +120,12 @@ export async function captureEvidence(
   let thumbnailPath: string | undefined;
   let dimensionNote: string | undefined;
   if (mode === "thumbnail") {
-    type ResizeResult = ResizedImageDimensions & { data: string; mimeType: string };
-    const resizeImage = Reflect.get(PiRuntime, ["resize", "Image"].join("")) as
-      | ((
-          data: Buffer,
-          mimeType: string,
-          options: Record<string, number>,
-        ) => Promise<ResizeResult | undefined>)
-      | undefined;
-    const resized =
-      typeof resizeImage === "function"
-        ? await resizeImage(readFileSync(planned.path), "image/png", {
-            maxWidth: viewport?.width ?? 1440,
-            maxHeight: viewport?.height ?? 1000,
-            maxBytes: 1_500_000,
-            jpegQuality: 55,
-          })
-        : undefined;
+    const resized = await resizeImage(readFileSync(planned.path), "image/png", {
+      maxWidth: viewport?.width ?? 1440,
+      maxHeight: viewport?.height ?? 1000,
+      maxBytes: 1_500_000,
+      jpegQuality: 55,
+    });
     if (resized) {
       thumbnailPath = thumbnailPathForMime(planned.thumbnailPath, resized.mimeType);
       writeFileSync(thumbnailPath, Buffer.from(resized.data, "base64"));

--- a/extensions/sf-browser/lib/operations.ts
+++ b/extensions/sf-browser/lib/operations.ts
@@ -3,12 +3,12 @@
  * Shared command/tool operations for SF Browser.
  */
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import * as PiRuntime from "@earendil-works/pi-coding-agent";
 import {
   formatDimensionNote,
-  resizeImage,
-  type ExtensionAPI,
-  type ExtensionContext,
-} from "@earendil-works/pi-coding-agent";
+  type ResizedImageDimensions,
+} from "../../../lib/common/pi-sdk-compat.ts";
 import type { ImageContent, TextContent } from "@earendil-works/pi-ai";
 import { markLatestBrowserSnapshotStale } from "../../../lib/common/sf-browser-snapshot-state.ts";
 import { runAgentBrowser } from "./agent-browser.ts";
@@ -120,12 +120,25 @@ export async function captureEvidence(
   let thumbnailPath: string | undefined;
   let dimensionNote: string | undefined;
   if (mode === "thumbnail") {
-    const resized = await resizeImage(readFileSync(planned.path), "image/png", {
-      maxWidth: viewport?.width ?? 1440,
-      maxHeight: viewport?.height ?? 1000,
-      maxBytes: 1_500_000,
-      jpegQuality: 55,
-    });
+    type ResizeResult = ResizedImageDimensions & { data: string; mimeType: string };
+    const resizeImage = (
+      PiRuntime as {
+        resizeImage?: (
+          data: Buffer,
+          mimeType: string,
+          options: Record<string, number>,
+        ) => Promise<ResizeResult | undefined>;
+      }
+    ).resizeImage;
+    const resized =
+      typeof resizeImage === "function"
+        ? await resizeImage(readFileSync(planned.path), "image/png", {
+            maxWidth: viewport?.width ?? 1440,
+            maxHeight: viewport?.height ?? 1000,
+            maxBytes: 1_500_000,
+            jpegQuality: 55,
+          })
+        : undefined;
     if (resized) {
       thumbnailPath = thumbnailPathForMime(planned.thumbnailPath, resized.mimeType);
       writeFileSync(thumbnailPath, Buffer.from(resized.data, "base64"));

--- a/extensions/sf-code-analyzer/lib/auto-scan.ts
+++ b/extensions/sf-code-analyzer/lib/auto-scan.ts
@@ -13,7 +13,7 @@ import type {
   ExtensionContext,
   ToolResultEvent,
 } from "@earendil-works/pi-coding-agent";
-import { isEditToolResult, isWriteToolResult } from "@earendil-works/pi-coding-agent";
+import { isEditToolResult, isWriteToolResult } from "../../../lib/common/pi-sdk-compat.ts";
 import type { ExecFn } from "../../../lib/common/sf-environment/detect.ts";
 import { runApexGuru } from "./apexguru.ts";
 import { buildAutoScanFollowUp } from "./auto-scan-followup.ts";

--- a/extensions/sf-code-analyzer/lib/transcript.ts
+++ b/extensions/sf-code-analyzer/lib/transcript.ts
@@ -33,7 +33,12 @@ export interface CodeAnalyzerTranscriptEntry {
 }
 
 export function registerCodeAnalyzerTranscriptRenderer(pi: ExtensionAPI): void {
-  pi.registerEntryRenderer<CodeAnalyzerTranscriptEntry>(
+  const registerEntryRenderer = (
+    pi as ExtensionAPI & { registerEntryRenderer?: ExtensionAPI["registerEntryRenderer"] }
+  ).registerEntryRenderer;
+  if (typeof registerEntryRenderer !== "function") return;
+  registerEntryRenderer.call(
+    pi,
     CODE_ANALYZER_TRANSCRIPT_TYPE,
     createCodeAnalyzerTranscriptRenderer(),
   );

--- a/extensions/sf-data360/lib/truncation.ts
+++ b/extensions/sf-data360/lib/truncation.ts
@@ -7,9 +7,9 @@ import {
   DEFAULT_MAX_LINES,
   formatSize,
   truncateHead,
-  withFileMutationQueue,
   type TruncationResult,
 } from "@earendil-works/pi-coding-agent";
+import { withFileMutationQueue } from "../../../lib/common/pi-sdk-compat.ts";
 import type { SfPiToolResultEnvelope } from "../../../lib/common/display/types.ts";
 
 export type D360OutputMode = "inline" | "summary" | "file_only";

--- a/extensions/sf-data360/lib/v2/result-presenter.ts
+++ b/extensions/sf-data360/lib/v2/result-presenter.ts
@@ -11,7 +11,7 @@
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { withFileMutationQueue } from "@earendil-works/pi-coding-agent";
+import { withFileMutationQueue } from "../../../../lib/common/pi-sdk-compat.ts";
 
 import type { SfPiToolResultEnvelope } from "../../../../lib/common/display/types.ts";
 import { buildD360Envelope, type D360OutputMode, type D360TruncatedOutput } from "../truncation.ts";

--- a/extensions/sf-lsp/index.ts
+++ b/extensions/sf-lsp/index.ts
@@ -32,7 +32,7 @@ import type {
   ExtensionContext,
   ToolResultEvent,
 } from "@earendil-works/pi-coding-agent";
-import { isEditToolResult, isWriteToolResult } from "@earendil-works/pi-coding-agent";
+import { isEditToolResult, isWriteToolResult } from "../../lib/common/pi-sdk-compat.ts";
 import { getLspDiagnosticsForFile, doctorLsp, shutdownLspClients } from "./lib/lsp-client.ts";
 import { getSfLspLanguageForFile, resolveToolPath } from "./lib/file-classify.ts";
 import {
@@ -178,8 +178,13 @@ export default function sfLspExtension(pi: ExtensionAPI) {
   let uiSettings: SfLspUiSettings = { verbose: false };
   const unavailableSeenByLanguage = new Set<SupportedLanguage>();
 
-  // --- Register human-only transcript entry renderer ----------------------------------------
-  pi.registerEntryRenderer(LSP_TRANSCRIPT_CUSTOM_TYPE, createTranscriptRenderer());
+  // OMP's legacy Pi shim does not currently expose human-only entry renderers.
+  const registerEntryRenderer = (
+    pi as ExtensionAPI & { registerEntryRenderer?: ExtensionAPI["registerEntryRenderer"] }
+  ).registerEntryRenderer;
+  if (typeof registerEntryRenderer === "function") {
+    registerEntryRenderer.call(pi, LSP_TRANSCRIPT_CUSTOM_TYPE, createTranscriptRenderer());
+  }
 
   // --- Core hooks -----------------------------------------------------------------------------
   registerMainCommand(pi);

--- a/extensions/sf-pi-manager/index.ts
+++ b/extensions/sf-pi-manager/index.ts
@@ -79,7 +79,7 @@ import {
   resolveEffectiveScope,
 } from "../../lib/common/sf-pi-package-state.ts";
 import { glyph, resolveGlyphMode } from "../../lib/common/glyph-policy.ts";
-import { requirePiVersion } from "../../lib/common/pi-compat.ts";
+import { getPiRuntimeFlavor, requirePiVersion } from "../../lib/common/pi-compat.ts";
 import { withSafeCommandHandler } from "../../lib/common/safe-command-handler.ts";
 import {
   describeDisplaySettingsSource,
@@ -225,14 +225,20 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const PACKAGE_ROOT = path.resolve(__dirname, "../..");
 
-const PACKAGE_VERSION: string = (() => {
+const PACKAGE_MANIFEST: {
+  version?: string;
+  omp?: { extensions?: string[] };
+} = (() => {
   try {
-    const pkg = JSON.parse(readFileSync(path.join(PACKAGE_ROOT, "package.json"), "utf8"));
-    return typeof pkg.version === "string" ? pkg.version : "0.0.0";
+    return JSON.parse(readFileSync(path.join(PACKAGE_ROOT, "package.json"), "utf8"));
   } catch {
-    return "0.0.0";
+    return {};
   }
 })();
+const PACKAGE_VERSION = PACKAGE_MANIFEST.version ?? "0.0.0";
+const OMP_EXTENSION_FILES = new Set(
+  (PACKAGE_MANIFEST.omp?.extensions ?? []).map((entry) => entry.replace(/^\.\//, "")),
+);
 
 // -------------------------------------------------------------------------------------------------
 // Types
@@ -274,12 +280,21 @@ type CommandArgs = {
 
 export default function sfPiManagerExtension(pi: ExtensionAPI) {
   if (!requirePiVersion(pi, "sf-pi-manager")) return;
+  const isOmp = getPiRuntimeFlavor() === "omp";
 
   const autoUpdateCoordinator = createAgentSettledUpdateCoordinator(pi);
   registerAutoUpdateTranscript(pi);
 
   pi.events.on(SF_PI_MANAGER_OPEN_EVENT, (request: SfPiManagerOpenRequest) => {
     request.accept?.();
+    if (isOmp) {
+      request.ctx.ui.notify(
+        "Use OMP's /extensions or `omp plugin` controls to manage sf-pi on Oh My Pi.",
+        "info",
+      );
+      request.resolve?.();
+      return;
+    }
     void handleOverlay(pi, request.ctx, resolveEffectiveScope(request.ctx.cwd), request.route).then(
       request.resolve,
       request.reject,
@@ -314,7 +329,9 @@ export default function sfPiManagerExtension(pi: ExtensionAPI) {
     // currently undefined. Respects an explicit `true` user opt-in.
     // Emits a one-time pi.appendEntry notice on the session that flips it.
     try {
-      const result = assertTelemetryDefault({ sfPiVersion: PACKAGE_VERSION });
+      const result = isOmp
+        ? { shouldNotify: false }
+        : assertTelemetryDefault({ sfPiVersion: PACKAGE_VERSION });
       if (result.shouldNotify && ctx.hasUI) {
         // Surface the one-time notice as a passive notification. We use
         // notify rather than appendEntry-driven output so the user sees
@@ -345,6 +362,7 @@ export default function sfPiManagerExtension(pi: ExtensionAPI) {
     updateDoctorNudge(ctx);
 
     if (doctorRefreshTimer) clearTimeout(doctorRefreshTimer);
+    if (isOmp) return;
     doctorRefreshTimer = setTimeout(() => {
       if (isAbortedSafe(ctx)) return;
       void refreshRuntimeDiagnosticsCache()
@@ -567,6 +585,23 @@ async function handleCommand(
   autoUpdateRunner: ManualAutoUpdateRunner,
 ): Promise<void> {
   const args = parseCommandArgs(raw);
+  if (getPiRuntimeFlavor() === "omp") {
+    if (["overlay", "list", "status"].includes(args.subcommand)) {
+      handleOmpStatus(ctx);
+      return;
+    }
+    if (
+      ["enable", "disable", "enable-all", "disable-all", "telemetry", "auto-update"].includes(
+        args.subcommand,
+      )
+    ) {
+      ctx.ui.notify(
+        "This setting is owned by Oh My Pi. Use OMP's /extensions or `omp plugin` controls instead.",
+        "info",
+      );
+      return;
+    }
+  }
   // Resolve scope here so handlers always receive a concrete value but
   // parseCommandArgs stays pure (no fs access — keeps unit tests fast).
   const scope = args.scope ?? resolveEffectiveScope(ctx.cwd);
@@ -746,6 +781,18 @@ function collectOverlayActions(
   for (const action of discovered) byId.set(action.id, action);
   for (const action of direct) byId.set(action.id, action);
   return [...byId.values()];
+}
+
+function handleOmpStatus(ctx: ExtensionCommandContext): void {
+  const extensions = SF_PI_REGISTRY.filter((entry) => OMP_EXTENSION_FILES.has(entry.file));
+  const lines = [
+    `sf-pi v${PACKAGE_VERSION} — Oh My Pi compatibility profile`,
+    `${extensions.length} bundled extensions are available on OMP 17.1.3+ (< 18).`,
+    "Manage extension and plugin state with OMP's /extensions or `omp plugin` controls.",
+    "",
+    ...extensions.map((entry) => `  ● ${entry.name} [${entry.category}]`),
+  ];
+  ctx.ui.notify(lines.join("\n"), "info");
 }
 
 async function handleList(
@@ -988,8 +1035,10 @@ function handleHelp(ctx: ExtensionCommandContext): void {
 // -------------------------------------------------------------------------------------------------
 
 function updateFooterStatus(ctx: ExtensionContext): void {
-  const globalDisabled = getDisabledExtensionsForCwd(ctx.cwd);
-  const states = buildExtensionStates(globalDisabled);
+  const states =
+    getPiRuntimeFlavor() === "omp"
+      ? buildExtensionStates(new Set()).filter((entry) => OMP_EXTENSION_FILES.has(entry.file))
+      : buildExtensionStates(getDisabledExtensionsForCwd(ctx.cwd));
   const enabledCount = states.filter((e) => e.enabled).length;
   // Glyph policy swaps `📦` for `[]` on terminals without emoji font
   // fallback so the bottom-bar status stays readable instead of tofu.

--- a/extensions/sf-skills/index.ts
+++ b/extensions/sf-skills/index.ts
@@ -32,11 +32,11 @@ import {
   buildSessionContext,
   loadSkills,
   loadSkillsFromDir,
-  parseSkillBlock,
   type ExtensionAPI,
   type ExtensionCommandContext,
   type ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
+import { parseSkillBlock } from "../../lib/common/pi-sdk-compat.ts";
 import { SkillsHudComponent } from "./lib/hud-component.ts";
 import {
   buildSkillsHudState,

--- a/extensions/sf-slack/lib/truncation.ts
+++ b/extensions/sf-slack/lib/truncation.ts
@@ -9,8 +9,8 @@ import {
   truncateHead,
   truncateTail,
   type TruncationResult,
-  withFileMutationQueue,
 } from "@earendil-works/pi-coding-agent";
+import { withFileMutationQueue } from "../../../lib/common/pi-sdk-compat.ts";
 import type { SfPiToolResultEnvelope } from "../../../lib/common/display/types.ts";
 
 export type SlackTruncationStrategy = "head" | "tail";

--- a/lib/common/human-only-command-output.ts
+++ b/lib/common/human-only-command-output.ts
@@ -16,10 +16,13 @@ export interface HumanOnlyCommandOutput {
 }
 
 export function registerHumanOnlyCommandOutput(pi: ExtensionAPI, customType: string): void {
-  pi.registerEntryRenderer<HumanOnlyCommandOutput>(
-    customType,
-    createHumanOnlyCommandOutputRenderer(),
-  );
+  const registerEntryRenderer = (
+    pi as ExtensionAPI & {
+      registerEntryRenderer?: ExtensionAPI["registerEntryRenderer"];
+    }
+  ).registerEntryRenderer;
+  if (typeof registerEntryRenderer !== "function") return;
+  registerEntryRenderer.call(pi, customType, createHumanOnlyCommandOutputRenderer());
 }
 
 export function createHumanOnlyCommandOutputRenderer(): EntryRenderer<HumanOnlyCommandOutput> {

--- a/lib/common/pi-compat.ts
+++ b/lib/common/pi-compat.ts
@@ -14,9 +14,16 @@
  *   releases load with one process-wide forward-compatibility warning.
  */
 import * as PiRuntime from "@earendil-works/pi-coding-agent";
+import path from "node:path";
 
 /** Oldest Pi release whose public APIs satisfy every bundled extension. */
 export const MIN_PI_VERSION = "0.81.1";
+
+/** Oldest Oh My Pi release whose legacy Pi compatibility layer is supported. */
+export const MIN_OMP_VERSION = "17.1.3";
+
+/** OMP majors are audited independently because they do not follow Pi's 0.x versions. */
+export const MAX_OMP_VERSION_EXCLUSIVE = "18.0.0";
 
 /** Exclusive end of the exact runtime range covered by required compatibility CI. */
 export const AUDITED_MAX_PI_VERSION_EXCLUSIVE = "0.83.0";
@@ -29,6 +36,49 @@ export const RECOMMENDED_PI_VERSION = "0.82.0";
 
 export type PiVersionCompatibility =
   "audited" | "forward-compatible" | "too-old" | "prerelease" | "major-version";
+
+export type PiRuntimeFlavor = "pi" | "omp";
+
+export interface RuntimeFlavorSignals {
+  version?: string;
+  agentDir?: string;
+  execPath?: string;
+  argv?: string[];
+}
+
+/**
+ * Identify OMP without depending on OMP-only imports, which would make the
+ * normal Pi runtime fail module resolution. The compiled OMP binary is named
+ * `omp`; source/npm launches retain an `omp` argv entry. The version + agent
+ * directory fallback covers wrappers while avoiding a false positive for Pi.
+ */
+export function detectPiRuntimeFlavor(signals: RuntimeFlavorSignals = {}): PiRuntimeFlavor {
+  const executableNames = [signals.execPath, ...(signals.argv ?? [])]
+    .filter((value): value is string => typeof value === "string" && value.length > 0)
+    .map((value) => path.basename(value).toLowerCase());
+  if (executableNames.some((name) => name === "omp" || name === "omp.exe")) return "omp";
+
+  const major = Number.parseInt(signals.version?.split(".", 1)[0] ?? "", 10);
+  const normalizedAgentDir = signals.agentDir?.replaceAll("\\", "/").toLowerCase();
+  if (Number.isFinite(major) && major >= 1 && normalizedAgentDir?.includes("/.omp/")) return "omp";
+
+  return "pi";
+}
+
+function currentRuntimeFlavor(installed: string | undefined): PiRuntimeFlavor {
+  const getAgentDir = (PiRuntime as { getAgentDir?: () => string }).getAgentDir;
+  return detectPiRuntimeFlavor({
+    version: installed,
+    agentDir: typeof getAgentDir === "function" ? getAgentDir() : undefined,
+    execPath: process.execPath,
+    argv: process.argv,
+  });
+}
+
+/** Active host family for behavior that cannot be expressed through the shared API. */
+export function getPiRuntimeFlavor(): PiRuntimeFlavor {
+  return currentRuntimeFlavor(getInstalledPiVersion());
+}
 
 /** Cached host version; stable for the life of the Pi process. */
 let cachedPiVersion: string | undefined | null = null;
@@ -115,6 +165,22 @@ export function requirePiVersion(
 ): boolean {
   const installed = getInstalledPiVersion();
   if (!installed) return true;
+
+  if (currentRuntimeFlavor(installed) === "omp") {
+    const supported =
+      compareVersions(installed, MIN_OMP_VERSION) >= 0 &&
+      compareVersions(installed, MAX_OMP_VERSION_EXCLUSIVE) < 0 &&
+      !installed.split("+", 1)[0]?.includes("-");
+    if (supported) return true;
+
+    if (!warnedBlockedExtensions.has(extensionName)) {
+      warnedBlockedExtensions.add(extensionName);
+      console.warn(
+        `[sf-pi] Skipping "${extensionName}": requires stable Oh My Pi >= ${MIN_OMP_VERSION} and < ${MAX_OMP_VERSION_EXCLUSIVE}; found ${installed}.`,
+      );
+    }
+    return false;
+  }
 
   const compatibility = classifyPiVersion(
     installed,

--- a/lib/common/pi-sdk-compat.ts
+++ b/lib/common/pi-sdk-compat.ts
@@ -38,20 +38,6 @@ export function parseSkillBlock(text: string): ParsedSkillBlock | null {
   };
 }
 
-export interface ResizedImageDimensions {
-  wasResized: boolean;
-  originalWidth: number;
-  originalHeight: number;
-  width: number;
-  height: number;
-}
-
-export function formatDimensionNote(result: ResizedImageDimensions): string | undefined {
-  if (!result.wasResized) return undefined;
-  const scale = result.originalWidth / result.width;
-  return `[Image: original ${result.originalWidth}x${result.originalHeight}, displayed at ${result.width}x${result.height}. Multiply coordinates by ${scale.toFixed(2)} to map to original image.]`;
-}
-
 const fileMutationQueues = new Map<string, Promise<void>>();
 let registrationQueue: Promise<void> = Promise.resolve();
 

--- a/lib/common/pi-sdk-compat.ts
+++ b/lib/common/pi-sdk-compat.ts
@@ -1,0 +1,106 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/**
+ * Small host-neutral equivalents of Pi SDK convenience helpers.
+ *
+ * Oh My Pi's legacy Pi module shim intentionally exposes a narrower runtime
+ * surface than current Pi. Keep these stable, trivial helpers local so sf-pi
+ * can run on either host without importing symbols that OMP does not export.
+ */
+import { realpath } from "node:fs/promises";
+import path from "node:path";
+import type { ToolResultEvent } from "@earendil-works/pi-coding-agent";
+
+export function isEditToolResult(event: ToolResultEvent): boolean {
+  return event.toolName === "edit";
+}
+
+export function isWriteToolResult(event: ToolResultEvent): boolean {
+  return event.toolName === "write";
+}
+
+export interface ParsedSkillBlock {
+  name: string;
+  location: string;
+  content: string;
+  userMessage?: string;
+}
+
+export function parseSkillBlock(text: string): ParsedSkillBlock | null {
+  const match = text.match(
+    /^<skill name="([^"]+)" location="([^"]+)">\n([\s\S]*?)\n<\/skill>(?:\n\n([\s\S]+))?$/,
+  );
+  if (!match) return null;
+  return {
+    name: match[1]!,
+    location: match[2]!,
+    content: match[3]!,
+    userMessage: match[4]?.trim() || undefined,
+  };
+}
+
+export interface ResizedImageDimensions {
+  wasResized: boolean;
+  originalWidth: number;
+  originalHeight: number;
+  width: number;
+  height: number;
+}
+
+export function formatDimensionNote(result: ResizedImageDimensions): string | undefined {
+  if (!result.wasResized) return undefined;
+  const scale = result.originalWidth / result.width;
+  return `[Image: original ${result.originalWidth}x${result.originalHeight}, displayed at ${result.width}x${result.height}. Multiply coordinates by ${scale.toFixed(2)} to map to original image.]`;
+}
+
+const fileMutationQueues = new Map<string, Promise<void>>();
+let registrationQueue: Promise<void> = Promise.resolve();
+
+function isMissingPathError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error.code === "ENOENT" || error.code === "ENOTDIR")
+  );
+}
+
+async function mutationQueueKey(filePath: string): Promise<string> {
+  const resolvedPath = path.resolve(filePath);
+  try {
+    return await realpath(resolvedPath);
+  } catch (error) {
+    if (isMissingPathError(error)) return resolvedPath;
+    throw error;
+  }
+}
+
+/** Serialize mutations to the same file while allowing different files in parallel. */
+export async function withFileMutationQueue<T>(
+  filePath: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const registration = registrationQueue.then(async () => {
+    const key = await mutationQueueKey(filePath);
+    const currentQueue = fileMutationQueues.get(key) ?? Promise.resolve();
+    let releaseNext!: () => void;
+    const nextQueue = new Promise<void>((resolve) => {
+      releaseNext = resolve;
+    });
+    const chainedQueue = currentQueue.then(() => nextQueue);
+    fileMutationQueues.set(key, chainedQueue);
+    return { key, currentQueue, chainedQueue, releaseNext };
+  });
+  registrationQueue = registration.then(
+    () => undefined,
+    () => undefined,
+  );
+
+  const { key, currentQueue, chainedQueue, releaseNext } = await registration;
+  await currentQueue;
+  try {
+    return await operation();
+  } finally {
+    releaseNext();
+    if (fileMutationQueues.get(key) === chainedQueue) fileMutationQueues.delete(key);
+  }
+}

--- a/lib/common/skill-detection/detection.ts
+++ b/lib/common/skill-detection/detection.ts
@@ -19,12 +19,12 @@
  * duplicating it. Behavior is unchanged from that prior version.
  */
 import path from "node:path";
-import {
-  parseSkillBlock,
-  type SessionContext,
-  type SessionEntry,
-  type SlashCommandInfo,
+import type {
+  SessionContext,
+  SessionEntry,
+  SlashCommandInfo,
 } from "@earendil-works/pi-coding-agent";
+import { parseSkillBlock } from "../pi-sdk-compat.ts";
 
 // -------------------------------------------------------------------------------------------------
 // Types

--- a/lib/common/tests/pi-compat.test.ts
+++ b/lib/common/tests/pi-compat.test.ts
@@ -16,9 +16,12 @@ import {
   AUDITED_MAX_PI_VERSION_EXCLUSIVE,
   classifyPiVersion,
   compareVersions,
+  detectPiRuntimeFlavor,
   getInstalledPiVersion,
   HARD_MAX_PI_VERSION_EXCLUSIVE,
   isPiVersionLoadable,
+  MAX_OMP_VERSION_EXCLUSIVE,
+  MIN_OMP_VERSION,
   MIN_PI_VERSION,
   requirePiVersion,
 } from "../pi-compat.ts";
@@ -97,6 +100,23 @@ describe("pi version floor", () => {
     }
   });
 
+  it("declares the audited OMP compatibility profile", () => {
+    const pkg = JSON.parse(readFileSync(path.resolve("package.json"), "utf8")) as {
+      omp?: { extensions?: string[] };
+    };
+    const ompExtensions = new Set(
+      (pkg.omp?.extensions ?? []).map((entry) => entry.replace(/^\.\//, "")),
+    );
+
+    expect(MIN_OMP_VERSION).toBe("17.1.3");
+    expect(MAX_OMP_VERSION_EXCLUSIVE).toBe("18.0.0");
+    expect(ompExtensions).toContain("extensions/sf-pi-manager/index.ts");
+    expect(ompExtensions).toContain("extensions/sf-brain/index.ts");
+    expect(ompExtensions).toContain("extensions/sf-data360/index.ts");
+    expect(ompExtensions).not.toContain("extensions/sf-llm-gateway-internal/index.ts");
+    expect(ompExtensions).not.toContain("extensions/sf-agentscript/index.ts");
+  });
+
   it("tracks the forward-compatible peer range and exact audited development SDK", () => {
     const pkg = JSON.parse(readFileSync(path.resolve("package.json"), "utf8")) as {
       peerDependencies?: Record<string, string>;
@@ -110,6 +130,36 @@ describe("pi version floor", () => {
     expect(pkg.devDependencies?.["@earendil-works/pi-coding-agent"]).toBe("0.82.0");
     expect(pkg.devDependencies?.["@earendil-works/pi-ai"]).toBe("0.82.0");
     expect(pkg.devDependencies?.["@earendil-works/pi-tui"]).toBe("0.82.0");
+  });
+});
+
+describe("runtime flavor detection", () => {
+  it("detects compiled and source OMP launches", () => {
+    expect(detectPiRuntimeFlavor({ execPath: "/opt/homebrew/bin/omp" })).toBe("omp");
+    expect(
+      detectPiRuntimeFlavor({
+        version: "17.1.3",
+        execPath: "/usr/local/bin/bun",
+        argv: ["bun", "/pkg/src/cli.ts", "omp"],
+      }),
+    ).toBe("omp");
+    expect(
+      detectPiRuntimeFlavor({
+        version: "17.1.3",
+        agentDir: "/home/user/.omp/agent",
+        execPath: "/usr/local/bin/wrapper",
+      }),
+    ).toBe("omp");
+  });
+
+  it("does not mistake normal Pi for OMP", () => {
+    expect(
+      detectPiRuntimeFlavor({
+        version: "0.82.0",
+        agentDir: "/home/user/.pi/agent",
+        execPath: "/usr/local/bin/pi",
+      }),
+    ).toBe("pi");
   });
 });
 

--- a/lib/common/tests/pi-sdk-compat.test.ts
+++ b/lib/common/tests/pi-sdk-compat.test.ts
@@ -1,0 +1,55 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { describe, expect, it } from "vitest";
+import {
+  formatDimensionNote,
+  isEditToolResult,
+  isWriteToolResult,
+  parseSkillBlock,
+  withFileMutationQueue,
+} from "../pi-sdk-compat.ts";
+
+describe("Pi SDK compatibility helpers", () => {
+  it("recognizes edit and write tool results by public tool name", () => {
+    expect(isEditToolResult({ toolName: "edit" } as never)).toBe(true);
+    expect(isWriteToolResult({ toolName: "write" } as never)).toBe(true);
+    expect(isEditToolResult({ toolName: "read" } as never)).toBe(false);
+  });
+
+  it("parses Pi skill invocation blocks", () => {
+    expect(
+      parseSkillBlock('<skill name="sf-apex" location="/tmp/SKILL.md">\nBody\n</skill>\n\nRun it'),
+    ).toEqual({
+      name: "sf-apex",
+      location: "/tmp/SKILL.md",
+      content: "Body",
+      userMessage: "Run it",
+    });
+  });
+
+  it("formats resized-image coordinate guidance", () => {
+    expect(
+      formatDimensionNote({
+        wasResized: true,
+        originalWidth: 2000,
+        originalHeight: 1000,
+        width: 1000,
+        height: 500,
+      }),
+    ).toContain("Multiply coordinates by 2.00");
+  });
+
+  it("serializes operations targeting the same file", async () => {
+    const order: string[] = [];
+    const first = withFileMutationQueue("/tmp/sf-pi-omp-queue-test", async () => {
+      order.push("first:start");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      order.push("first:end");
+    });
+    const second = withFileMutationQueue("/tmp/sf-pi-omp-queue-test", async () => {
+      order.push("second");
+    });
+
+    await Promise.all([first, second]);
+    expect(order).toEqual(["first:start", "first:end", "second"]);
+  });
+});

--- a/lib/common/tests/pi-sdk-compat.test.ts
+++ b/lib/common/tests/pi-sdk-compat.test.ts
@@ -1,7 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import { describe, expect, it } from "vitest";
 import {
-  formatDimensionNote,
   isEditToolResult,
   isWriteToolResult,
   parseSkillBlock,
@@ -24,18 +23,6 @@ describe("Pi SDK compatibility helpers", () => {
       content: "Body",
       userMessage: "Run it",
     });
-  });
-
-  it("formats resized-image coordinate guidance", () => {
-    expect(
-      formatDimensionNote({
-        wasResized: true,
-        originalWidth: 2000,
-        originalHeight: 1000,
-        width: 1000,
-        height: 500,
-      }),
-    ).toContain("Multiply coordinates by 2.00");
   });
 
   it("serializes operations targeting the same file", async () => {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,23 @@
       "./themes"
     ]
   },
+  "omp": {
+    "extensions": [
+      "./extensions/sf-welcome/index.ts",
+      "./extensions/sf-devbar/index.ts",
+      "./extensions/sf-ohana-spinner/index.ts",
+      "./extensions/sf-pi-manager/index.ts",
+      "./extensions/sf-guardrail/index.ts",
+      "./extensions/sf-brain/index.ts",
+      "./extensions/sf-browser/index.ts",
+      "./extensions/sf-code-analyzer/index.ts",
+      "./extensions/sf-data360/index.ts",
+      "./extensions/sf-data-explorer/index.ts",
+      "./extensions/sf-herdr/index.ts",
+      "./extensions/sf-skills/index.ts",
+      "./extensions/sf-feedback/index.ts"
+    ]
+  },
   "scripts": {
     "generate-catalog": "node scripts/generate-catalog.mjs",
     "generate-catalog:check": "node scripts/generate-catalog.mjs --check",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
       "./extensions/sf-pi-manager/index.ts",
       "./extensions/sf-guardrail/index.ts",
       "./extensions/sf-brain/index.ts",
-      "./extensions/sf-browser/index.ts",
       "./extensions/sf-code-analyzer/index.ts",
       "./extensions/sf-data360/index.ts",
       "./extensions/sf-data-explorer/index.ts",


### PR DESCRIPTION
## Summary

- add an audited Oh My Pi (OMP) runtime gate for `>=17.1.3 <18.0.0`
- add a bounded `omp.extensions` profile so OMP installs only extensions verified against its legacy Pi compatibility shim
- replace a small set of missing Pi SDK convenience exports with host-neutral local helpers
- gracefully degrade human-only transcript renderers when OMP does not expose `registerEntryRenderer`
- make `/sf-pi` report the OMP profile while directing enable/disable operations to OMP's native `/extensions` / `omp plugin` controls
- document OMP installation and the currently supported extension subset

## OMP profile

Welcome, DevBar, Ohana Spinner, Pi Manager, Guardrail, Brain, Code Analyzer, Data 360, Data Explorer, Herdr, Skills, and Feedback.

Extensions whose imports do not yet validate through OMP's legacy compatibility layer are intentionally omitted instead of making the whole plugin install fail.

## Validation

- `npm run format:check` ✅
- `npm run check` ✅
- focused Vitest suite: 30 tests passed ✅
- isolated OMP `plugin link` runtime smoke: 0 extension-load errors ✅
- fresh-cache remote OMP install from this branch: install + extension validation passed ✅
- `npm run validate`: 3,577 tests passed; 13 existing failures remain. Representative failing files reproduce unchanged on `origin/main` (SF Docs credential security, SF Skills config panel, and SF Welcome CLI status).
