### PR TITLE
fix(security): patch dependency advisories and file race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 
 ### Changed
 
+- **Cleared the open dependency and CodeQL security findings.** The lockfile now resolves `js-yaml` 4.3.1, `postcss` 8.5.26, and its required `nanoid` 3.3.17 patch; the AgentFabric parity test uses `Dirent` metadata instead of a separate path `stat` before reading files.
 - **Normalized current Herdr pane-run success and clarified Herdr identities.** SF Herdr now converts only the known exit-zero empty-body `herdr_pane.run` result into submitted success without retrying, command plans use the bounded `wait_output` snapshot instead of a redundant pane read, and SF Welcome reports the installed Herdr runtime/channel, Pi control-package version, protocol, and Pi bridge schema without claiming release freshness.
 - **Advanced the audited Pi runtime edge to 0.84 without raising the 0.82 floor.** Development packages and repair guidance now use exact Pi 0.84.0, required nightly compatibility covers 0.82/0.83/0.84, and Gateway discovery uses Pi 0.84's provider-scoped cancellable refresh while older supported runtimes keep their existing fallback behavior.
 - **Added advisory Salesforce Instruction Surface diagnostics and behavior regression.** SF Brain reports content-safe counts and bundled-baseline deltas in the Manager and through `npm run instruction-surface:report`; the opt-in behavior harness allows local context reads and blocks every non-local tool before execution.

--- a/extensions/sf-agentscript/tests/agentfabric-graph-parity.test.ts
+++ b/extensions/sf-agentscript/tests/agentfabric-graph-parity.test.ts
@@ -7,7 +7,7 @@
  * invocations as edges. Keep this characterization explicit so a future pinned
  * package refresh makes new upstream coverage visible for parity review.
  */
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import * as ts from "typescript";
 import { describe, expect, test } from "vitest";
@@ -120,11 +120,12 @@ describe("AgentFabric graph parity insight", () => {
     const extensionRoot = path.resolve("extensions/sf-agentscript");
     const importedBy: string[] = [];
     const visit = (dir: string): void => {
-      for (const entry of readdirSync(dir)) {
-        const candidate = path.join(dir, entry);
-        if (statSync(candidate).isDirectory()) {
-          if (entry !== "tests" && entry !== "docs") visit(candidate);
-        } else if (/\.(?:[cm]?ts|tsx)$/.test(candidate)) {
+      // Dirent metadata avoids a separate stat(path) check before each file read.
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const candidate = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          if (entry.name !== "tests" && entry.name !== "docs") visit(candidate);
+        } else if (entry.isFile() && /\.(?:[cm]?ts|tsx)$/.test(candidate)) {
           const source = readFileSync(candidate, "utf8");
           const file = ts.createSourceFile(candidate, source, ts.ScriptTarget.Latest, true);
           const walk = (node: ts.Node): void => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9181,9 +9181,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -9891,9 +9891,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",
@@ -10453,9 +10453,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -10472,7 +10472,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Summary

- update transitive `js-yaml` from 4.3.0 to 4.3.1
- update transitive `postcss` from 8.5.20 to 8.5.26 and its required `nanoid` patch
- replace the AgentFabric parity test's separate `stat(path)` check with `Dirent` metadata before source reads

This consolidates and supersedes Dependabot PRs #579 and #561 after merge.

## Security evidence

- `npm audit --json`: 0 vulnerabilities
- `npm audit --omit=dev --json`: 0 vulnerabilities
- targeted AgentFabric parity test: 4 passed

## Validation

- `npm ci --ignore-scripts --legacy-peer-deps`
- `npm run validate`
- `npm run eslint`
- `npm run check -- --pretty false`
