### PR TITLE
fix(code-analyzer): prevent stale context crash after reload

### DIFF
--- a/catalog/index.json
+++ b/catalog/index.json
@@ -271,7 +271,7 @@
     "entry": "extensions/sf-code-analyzer/index.ts",
     "hasReadme": true,
     "hasTests": true,
-    "srcLoc": 4452
+    "srcLoc": 4462
   },
   {
     "id": "sf-data-explorer",

--- a/extensions/sf-code-analyzer/index.ts
+++ b/extensions/sf-code-analyzer/index.ts
@@ -205,7 +205,14 @@ export default function sfCodeAnalyzer(pi: ExtensionAPI) {
   if (!requirePiVersion(pi, "sf-code-analyzer")) return;
 
   let toolsRegistered = false;
+  let readinessTimer: ReturnType<typeof setTimeout> | undefined;
   const exec = buildExecFn(pi);
+
+  function clearReadinessTimer(): void {
+    if (readinessTimer === undefined) return;
+    clearTimeout(readinessTimer);
+    readinessTimer = undefined;
+  }
 
   function ensureToolsRegistered(): void {
     if (toolsRegistered) return;
@@ -219,22 +226,26 @@ export default function sfCodeAnalyzer(pi: ExtensionAPI) {
 
   pi.on("session_start", (event, ctx) => {
     beginSalesforceConnectionSession(event);
+    clearReadinessTimer();
     if (event.reason === "reload") toolsRegistered = false;
-    if (isSfPiExtensionEnabled(ctx.cwd, "sf-code-analyzer")) ensureToolsRegistered();
-    if (ctx.hasUI && isSfPiExtensionEnabled(ctx.cwd, "sf-code-analyzer")) {
-      const timer = setTimeout(() => {
+    const cwd = ctx.cwd;
+    if (isSfPiExtensionEnabled(cwd, "sf-code-analyzer")) ensureToolsRegistered();
+    if (ctx.hasUI && isSfPiExtensionEnabled(cwd, "sf-code-analyzer")) {
+      readinessTimer = setTimeout(() => {
+        readinessTimer = undefined;
         void refreshCodeAnalyzerReadiness(exec).catch(() => {
           // Cache refresh is best-effort. Doctor surfaces the error when requested.
         });
-        void refreshApexGuruReadiness(undefined, ctx.cwd).catch(() => {
+        void refreshApexGuruReadiness(undefined, cwd).catch(() => {
           // ApexGuru readiness is optional and must not affect startup.
         });
       }, 6_000);
-      timer.unref?.();
+      readinessTimer.unref?.();
     }
   });
 
   pi.on("session_shutdown", () => {
+    clearReadinessTimer();
     toolsRegistered = false;
   });
 

--- a/extensions/sf-code-analyzer/tests/session-lifecycle.test.ts
+++ b/extensions/sf-code-analyzer/tests/session-lifecycle.test.ts
@@ -1,0 +1,122 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../lib/common/sf-pi-extension-state.ts", () => ({
+  isSfPiExtensionEnabled: vi.fn(() => true),
+}));
+
+vi.mock("../lib/readiness.ts", async () => {
+  const actual = await vi.importActual<typeof import("../lib/readiness.ts")>("../lib/readiness.ts");
+  return {
+    ...actual,
+    refreshCodeAnalyzerReadiness: vi.fn(() => Promise.resolve()),
+  };
+});
+
+vi.mock("../lib/apexguru-readiness.ts", async () => {
+  const actual = await vi.importActual<typeof import("../lib/apexguru-readiness.ts")>(
+    "../lib/apexguru-readiness.ts",
+  );
+  return {
+    ...actual,
+    refreshApexGuruReadiness: vi.fn(() => Promise.resolve()),
+  };
+});
+
+type Listener = (...args: unknown[]) => void;
+
+function eventBus() {
+  const listeners = new Map<string, Listener[]>();
+  return {
+    on(eventName: string, listener: Listener) {
+      listeners.set(eventName, [...(listeners.get(eventName) ?? []), listener]);
+    },
+    emit(eventName: string, ...args: unknown[]) {
+      for (const listener of listeners.get(eventName) ?? []) listener(...args);
+    },
+  };
+}
+
+function fakePi(lifecycle: ReturnType<typeof eventBus>) {
+  return {
+    events: eventBus(),
+    on: lifecycle.on,
+    registerCommand: vi.fn(),
+    registerEntryRenderer: vi.fn(),
+    registerTool: vi.fn(),
+  };
+}
+
+function sessionContext(cwd: string) {
+  let active = true;
+  return {
+    hasUI: true,
+    get cwd() {
+      if (!active) throw new Error("session context is no longer active");
+      return cwd;
+    },
+    invalidate() {
+      active = false;
+    },
+  };
+}
+
+describe("sf-code-analyzer session lifecycle", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("cancels readiness work when the session shuts down", async () => {
+    const mod = await import("../index.ts");
+    const readiness = await import("../lib/apexguru-readiness.ts");
+    const lifecycle = eventBus();
+    const pi = fakePi(lifecycle);
+    const context = sessionContext("/old-session");
+
+    mod.default(pi as never);
+    lifecycle.emit("session_start", { reason: "startup" }, context);
+    context.invalidate();
+    lifecycle.emit("session_shutdown");
+
+    expect(() => vi.advanceTimersByTime(6_000)).not.toThrow();
+    expect(readiness.refreshApexGuruReadiness).not.toHaveBeenCalled();
+  });
+
+  it("cancels the previous readiness timer when a session reloads", async () => {
+    const mod = await import("../index.ts");
+    const readiness = await import("../lib/apexguru-readiness.ts");
+    const lifecycle = eventBus();
+    const pi = fakePi(lifecycle);
+    const oldContext = sessionContext("/old-session");
+    const currentContext = sessionContext("/current-session");
+
+    mod.default(pi as never);
+    lifecycle.emit("session_start", { reason: "startup" }, oldContext);
+    oldContext.invalidate();
+    lifecycle.emit("session_start", { reason: "reload" }, currentContext);
+
+    expect(() => vi.advanceTimersByTime(6_000)).not.toThrow();
+    expect(readiness.refreshApexGuruReadiness).toHaveBeenCalledTimes(1);
+    expect(readiness.refreshApexGuruReadiness).toHaveBeenCalledWith(undefined, "/current-session");
+  });
+
+  it("passes a startup cwd snapshot to readiness work for a live session", async () => {
+    const mod = await import("../index.ts");
+    const readiness = await import("../lib/apexguru-readiness.ts");
+    const lifecycle = eventBus();
+    const pi = fakePi(lifecycle);
+    const context = sessionContext("/stable-session");
+
+    mod.default(pi as never);
+    lifecycle.emit("session_start", { reason: "startup" }, context);
+    vi.advanceTimersByTime(6_000);
+    await vi.runAllTimersAsync();
+
+    expect(readiness.refreshApexGuruReadiness).toHaveBeenCalledWith(undefined, "/stable-session");
+  });
+});


### PR DESCRIPTION
## What this PR does

Fixes the `sf-code-analyzer` delayed ApexGuru readiness refresh so stale session contexts cannot crash Pi after reload or session shutdown.

## Why

The `session_start` handler scheduled a six-second callback that accessed `ctx.cwd` after the originating session could have been replaced. Pi correctly invalidates that context, so `/reload` during the startup window could surface an uncaught stale-context exception.

## How

- Snapshot `ctx.cwd` while the session context is active.
- Store and cancel the readiness timer on session replacement and `session_shutdown`.
- Add lifecycle regression coverage for shutdown, reload, and stable-session readiness behavior.
- Regenerate the catalog entry affected by the new test file.

## Checklist

- [x] I ran focused validation and listed it below.
- [ ] I updated the affected extension's `README.md` (not needed; this is an internal lifecycle fix).
- [x] I added or updated tests.
- [x] I regenerated the catalog as required for the extension file-tree change.
- [x] This PR is non-breaking.

## Security and public-surface checklist

- [x] I considered whether this adds or changes a high-value durable mutation exposed through an LLM-callable tool.
- [x] No durable mutation or new public tool surface is introduced.
- [x] Public code, tests, and comments use generic names and contain no secrets or private identifiers.

## Validation performed

- `PI_CODING_AGENT_DIR=<temporary-dir> PI_CODING_AGENT_SESSION_DIR=<temporary-dir> npm test -- extensions/sf-code-analyzer/tests` — 15 files, 54 tests passed.
- `npm run check:boot-path` — passed.
- `npm run generate-catalog:check` — passed.
- Targeted Prettier check on changed files — passed.
- Isolated Pi smoke test with the local extension source, immediate `/reload`, an eight-second wait, and `/quit` — completed without stale-context, uncaught, or `TypeError` output.
- Repository-wide `npm run check` remains blocked by unrelated existing Agent Script/Data 360 dependency and test errors; no changed-file errors were reported.

## Notes for reviewers

The readiness timer is now owned by the extension instance and cleared both before a replacement session schedules new work and when the session shuts down. The existing best-effort readiness behavior remains unchanged for stable sessions.
