### PR TITLE
chore(deps): update nanoid to 3.3.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9892,9 +9892,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

- update the transitive `nanoid` lockfile entry from 3.3.17 to 3.3.18
- clear the high-severity production audit finding reported by GHSA-2v37-7h3g-55p8
- restore the required `npm audit (production)` gate for open pull requests

No direct dependency declaration changes.

## Validation

- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- `npm run generate-catalog:check` — passed
- `npm run format:check` — passed
- `npm run check` — passed
- `npm test` — 557 files passed, 3,983 tests passed