### PR TITLE
chore(deps): update Dagre to 3.1.1 and Apex Node to 9.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,11 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@dagrejs/dagre": "3.0.0",
+        "@dagrejs/dagre": "3.1.1",
         "@lwc/compiler": "^9.3.6",
         "@lwc/template-compiler": "^9.3.4",
         "@salesforce-ux/design-system": "2.264.0",
-        "@salesforce/apex-node": "^9.0.0",
+        "@salesforce/apex-node": "^9.0.3",
         "@salesforce/core": "^9.1.0",
         "@salesforce/kit": "^4.0.0",
         "@salesforce/soql-common": "^2.0.0",
@@ -1591,18 +1591,18 @@
       }
     },
     "node_modules/@dagrejs/dagre": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-3.0.0.tgz",
-      "integrity": "sha512-ZzhnTy1rfuoew9Ez3EIw4L2znPGnYYhfn8vc9c4oB8iw6QAsszbiU0vRhlxWPFnmmNSFAkrYeF1PhM5m4lAN0Q==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-3.1.1.tgz",
+      "integrity": "sha512-zroZB1dFOFiGgv4Xcrn1DckB1o4aOikPqD2NDQPV0WM//CXGcS6xiD0rNkqHmw6FEg4tabt4nxPLwgCWT+Vb2A==",
       "license": "MIT",
       "dependencies": {
-        "@dagrejs/graphlib": "4.0.1"
+        "@dagrejs/graphlib": "4.0.5"
       }
     },
     "node_modules/@dagrejs/graphlib": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-4.0.1.tgz",
-      "integrity": "sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-4.0.5.tgz",
+      "integrity": "sha512-7xrBTqIts3o+PMUZX97wSc+7TUbW+/rULzGNCTP6yooNVDXbzw4Wutg/H/xOutTB/c/k0YqOAavgPh4/Zk9PFA==",
       "license": "MIT"
     },
     "node_modules/@docsearch/css": {
@@ -5255,12 +5255,12 @@
       }
     },
     "node_modules/@salesforce/apex-node": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/apex-node/-/apex-node-9.0.0.tgz",
-      "integrity": "sha512-OwOnUxaec9tBcWG2lqg8e7qmazpgzd4oUZuyaw/xbnz21pQAztfn2gAlZNGGnunAKtceyarO9iLygt/ebXJC/g==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@salesforce/apex-node/-/apex-node-9.0.3.tgz",
+      "integrity": "sha512-8vgtTAg3gPadhAPI4v0aX5kNjjsmU4vHaYEf0rwWOjJVBmruqQdGC9dnyBXy5WVpsOWGOIZGG3vGr8eMdUiUxA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "^9.0.0",
+        "@salesforce/core": "^9.1.0",
         "@salesforce/kit": "^4.0.0",
         "@types/istanbul-reports": "^3.0.4",
         "fast-glob": "^3.3.2",

--- a/package.json
+++ b/package.json
@@ -143,11 +143,11 @@
     "vitest": "^4.1.10"
   },
   "dependencies": {
-    "@dagrejs/dagre": "3.0.0",
+    "@dagrejs/dagre": "3.1.1",
     "@lwc/compiler": "^9.3.6",
     "@lwc/template-compiler": "^9.3.4",
     "@salesforce-ux/design-system": "2.264.0",
-    "@salesforce/apex-node": "^9.0.0",
+    "@salesforce/apex-node": "^9.0.3",
     "@salesforce/core": "^9.1.0",
     "@salesforce/kit": "^4.0.0",
     "@salesforce/soql-common": "^2.0.0",


### PR DESCRIPTION
## Summary

- update `@dagrejs/dagre` from 3.0.0 to 3.1.1
- update `@salesforce/apex-node` from 9.0.0 to 9.0.3
- supersede #596 without adopting its affected Dagre 3.1.0 release

Dagre 3.1.0 shared remembered layout state across unrelated graph instances and could crash during ordering. Version 3.1.1 scopes that state to each input graph ([upstream fix](https://github.com/dagrejs/dagre/commit/62809ca3c6a5b2edd8102ebf0bbb3c32e2251239)).

Other newly published grouped updates remain deferred to their normal dependency-cooldown cycle.

## Validation

- reproduced the unrelated-graph isolation crash with Dagre 3.1.0
- reran the same scenario with Dagre 3.1.1 — passed
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- `npm run generate-catalog:check` — passed
- `npm run format:check` — passed
- `npm run check` — passed
- `npm test` — 558 files passed, 3,986 tests passed