### PR TITLE
fix(devbar): repaint context after compaction

### DIFF
--- a/catalog/index.json
+++ b/catalog/index.json
@@ -407,6 +407,7 @@
       "session_start",
       "session_shutdown",
       "model_select",
+      "session_compact",
       "session_info_changed",
       "thinking_level_select",
       "turn_start",
@@ -429,7 +430,7 @@
     "entry": "extensions/sf-devbar/index.ts",
     "hasReadme": true,
     "hasTests": true,
-    "srcLoc": 2386
+    "srcLoc": 2392
   },
   {
     "id": "sf-docs",

--- a/catalog/registry.ts
+++ b/catalog/registry.ts
@@ -122,7 +122,7 @@ export const SF_PI_REGISTRY: readonly SfPiExtension[] = [
     maturity: "stable",
     defaultEnabled: true,
     commands: ["/sf-devbar","/sf-org"],
-    events: ["session_start","session_shutdown","model_select","session_info_changed","thinking_level_select","turn_start","turn_end","agent_end","before_agent_start","context"],
+    events: ["session_start","session_shutdown","model_select","session_compact","session_info_changed","thinking_level_select","turn_start","turn_end","agent_end","before_agent_start","context"],
     configurable: true,
     getConfigPanel: async () => {
       const mod = await import("../extensions/sf-devbar/lib/config-panel.ts");

--- a/docs/extensions/sf-devbar.md
+++ b/docs/extensions/sf-devbar.md
@@ -41,7 +41,7 @@ Open its Manager detail or change its package state with:
 - **Commands:** `/sf-devbar`, `/sf-org`
 - **LLM tools:** _none_
 - **Providers:** _none_
-- **Events/hooks:** `session_start`, `session_shutdown`, `model_select`, `session_info_changed`, `thinking_level_select`, `turn_start`, `turn_end`, `agent_end`, `before_agent_start`, `context`
+- **Events/hooks:** `session_start`, `session_shutdown`, `model_select`, `session_compact`, `session_info_changed`, `thinking_level_select`, `turn_start`, `turn_end`, `agent_end`, `before_agent_start`, `context`
 
 </details>
 

--- a/extensions/sf-devbar/index.ts
+++ b/extensions/sf-devbar/index.ts
@@ -16,6 +16,7 @@
  *   session_start         | Activate both bars, load cached org, start async checks
  *   session_shutdown      | Clear custom footer + widget
  *   model_select          | Update model name, detect SF LLM Gateway, refresh bars
+ *   session_compact       | Repaint context usage from Pi's post-compaction state
  *   session_info_changed  | Repaint the optional Pi session-name segment
  *   thinking_level_select | Repaint top bar immediately on thinking-level change
  *   turn_start            | Set thinking indicator on top bar
@@ -28,7 +29,7 @@
  *
  * Pi SDK features used:
  *   setWidget, setFooter, setTitle
- *   session_start, session_shutdown, model_select, session_info_changed
+ *   session_start, session_shutdown, model_select, session_compact, session_info_changed
  *   turn_start, turn_end, agent_end
  *   before_agent_start (with systemPromptOptions)
  *   registerCommand, registerShortcut, registerFlag
@@ -468,6 +469,12 @@ export default function sfDevBar(pi: ExtensionAPI) {
     if (!enabled || !ctx.hasUI || !isActiveSession(ctx)) return;
     updateTopBar(ctx);
     requestFooterRender?.();
+  });
+
+  // --- Successful compaction: replace stale pre-compaction usage immediately ---
+  pi.on("session_compact", async (_event, ctx) => {
+    if (!enabled || !ctx.hasUI || !isActiveSession(ctx)) return;
+    updateTopBar(ctx);
   });
 
   // --- Session name change: repaint from Pi's public getter ---

--- a/extensions/sf-devbar/manifest.json
+++ b/extensions/sf-devbar/manifest.json
@@ -11,6 +11,7 @@
     "session_start",
     "session_shutdown",
     "model_select",
+    "session_compact",
     "session_info_changed",
     "thinking_level_select",
     "turn_start",

--- a/extensions/sf-devbar/tests/compaction-repaint.test.ts
+++ b/extensions/sf-devbar/tests/compaction-repaint.test.ts
@@ -1,0 +1,122 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import {
+  SessionManager,
+  type ExtensionAPI,
+  type ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import sfDevBar from "../index.ts";
+
+function createHarness() {
+  const handlers = new Map<
+    string,
+    Array<(event: unknown, ctx: ExtensionContext) => Promise<unknown> | unknown>
+  >();
+  const tui = { requestRender: vi.fn() };
+  const theme = {
+    fg: (_color: string, text: string) => text,
+    bold: (text: string) => text,
+  };
+  let widget:
+    { render(width: number): string[]; invalidate(): void; dispose?: () => void } | undefined;
+
+  const ui = {
+    setWidget: vi.fn((_key: string, value: unknown) => {
+      if (typeof value === "function") {
+        widget = value(tui, theme);
+      } else if (value === undefined) {
+        widget = undefined;
+      }
+    }),
+    setFooter: vi.fn((value: unknown) => {
+      if (typeof value !== "function") return;
+      value(tui, theme, {
+        onBranchChange: () => () => undefined,
+        getGitBranch: () => null,
+        getExtensionStatuses: () => [],
+      });
+    }),
+    setTitle: vi.fn(),
+    notify: vi.fn(),
+    setStatus: vi.fn(),
+  };
+
+  const sessionManager = SessionManager.inMemory("/workspace/sf-devbar-compaction");
+  let contextUsage: ReturnType<ExtensionContext["getContextUsage"]> = {
+    tokens: 900_000,
+    contextWindow: 1_000_000,
+    percent: 90,
+  };
+  const ctx = {
+    cwd: "/workspace/sf-devbar-compaction",
+    hasUI: true,
+    mode: "tui",
+    model: {
+      provider: "sf-llm-gateway",
+      id: "example-model",
+      name: "Example Model",
+    },
+    sessionManager,
+    ui,
+    getContextUsage: () => contextUsage,
+    isProjectTrusted: () => true,
+  } as unknown as ExtensionContext;
+
+  const pi = {
+    events: new EventEmitter(),
+    on(event: string, handler: (event: unknown, eventCtx: ExtensionContext) => unknown) {
+      const eventHandlers = handlers.get(event) ?? [];
+      eventHandlers.push(handler);
+      handlers.set(event, eventHandlers);
+    },
+    registerFlag: vi.fn(),
+    getFlag: vi.fn(() => false),
+    registerCommand: vi.fn(),
+    registerShortcut: vi.fn(),
+    getThinkingLevel: vi.fn(() => "high"),
+    getSessionName: vi.fn(() => undefined),
+    exec: vi.fn(async () => ({ stdout: "", stderr: "", code: 0, killed: false })),
+    appendEntry: vi.fn(),
+  } as unknown as ExtensionAPI;
+
+  const emit = async (event: string, payload: unknown = { type: event }) => {
+    for (const handler of handlers.get(event) ?? []) {
+      await handler(payload, ctx);
+    }
+  };
+
+  return {
+    pi,
+    ctx,
+    tui,
+    emit,
+    getWidget: () => widget,
+    setContextUsage(value: typeof contextUsage) {
+      contextUsage = value;
+    },
+  };
+}
+
+describe("sf-devbar compaction repaint", () => {
+  it("repaints the context bar to Pi's unknown state after compaction", async () => {
+    vi.useFakeTimers();
+    const harness = createHarness();
+
+    try {
+      sfDevBar(harness.pi);
+      await harness.emit("session_start");
+      expect(harness.getWidget()?.render(160).join("\n")).toContain("90.0%");
+
+      harness.tui.requestRender.mockClear();
+      harness.setContextUsage({ tokens: null, contextWindow: 1_000_000, percent: null });
+      await harness.emit("session_compact");
+
+      expect(harness.tui.requestRender).toHaveBeenCalled();
+      expect(harness.getWidget()?.render(160).join("\n")).toContain("Context Window unknown");
+    } finally {
+      await harness.emit("session_shutdown", { type: "session_shutdown", reason: "quit" });
+      vi.useRealTimers();
+    }
+  });
+});

--- a/extensions/sf-llm-gateway/tests/compaction-routes-through-gateway.test.ts
+++ b/extensions/sf-llm-gateway/tests/compaction-routes-through-gateway.test.ts
@@ -1,26 +1,59 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /** Exact Pi compaction handoff through the complete Gateway Provider. */
-import { describe, expect, it, vi } from "vitest";
-import { generateSummary } from "@earendil-works/pi-coding-agent";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createAgentSession,
+  DefaultResourceLoader,
+  ModelRuntime,
+  SessionManager,
+  SettingsManager,
+} from "@earendil-works/pi-coding-agent";
 import {
   createAssistantMessageEventStream,
+  InMemoryCredentialStore,
+  InMemoryModelsStore,
   type Api,
   type ApiKeyAuth,
   type AssistantMessage,
   type Context,
-  type Message,
   type Model,
 } from "@earendil-works/pi-ai";
 import { PROVIDER_NAME } from "../lib/config.ts";
-import { toProviderModelConfig } from "../lib/models.ts";
-import type { GatewayProviderAuthController } from "../lib/provider-auth.ts";
+import {
+  GATEWAY_RESOLVED_ROOT_ENV,
+  type GatewayProviderAuthController,
+} from "../lib/provider-auth.ts";
 import {
   createGatewayProviderRuntime,
+  type GatewayFetchers,
   type GatewayStreamImplementations,
 } from "../lib/provider.ts";
 
-function summaryStream(model: Model<Api>, text = "[gateway summary]") {
+type CompletedStopReason = Extract<
+  AssistantMessage["stopReason"],
+  "stop" | "length" | "toolUse" | "deferred"
+>;
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function summaryStream(
+  model: Model<Api>,
+  text = "[gateway summary]",
+  stopReason: CompletedStopReason = "stop",
+  usage: Partial<AssistantMessage["usage"]> = {},
+) {
   const stream = createAssistantMessageEventStream();
+  const input = usage.input ?? 0;
+  const output = usage.output ?? 0;
+  const cacheRead = usage.cacheRead ?? 0;
+  const cacheWrite = usage.cacheWrite ?? 0;
   const message: AssistantMessage = {
     role: "assistant",
     content: [{ type: "text", text }],
@@ -28,106 +61,281 @@ function summaryStream(model: Model<Api>, text = "[gateway summary]") {
     provider: model.provider,
     model: model.id,
     usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
+      input,
+      output,
+      cacheRead,
+      cacheWrite,
+      totalTokens: usage.totalTokens ?? input + output + cacheRead + cacheWrite,
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
     },
-    stopReason: "stop",
+    stopReason,
     timestamp: Date.now(),
   };
   queueMicrotask(() => {
     stream.push({ type: "start", partial: message });
-    stream.push({ type: "done", reason: "stop", message });
+    stream.push({ type: "done", reason: stopReason, message });
     stream.end();
   });
   return stream;
 }
 
-function userMessages(model: Model<Api>): Message[] {
-  return [
-    {
-      role: "user",
-      content: [{ type: "text", text: "Help me with a Salesforce thing." }],
-      timestamp: Date.now(),
-    },
-    {
-      role: "assistant",
-      content: [{ type: "text", text: "Sure, what do you need?" }],
-      api: model.api,
-      provider: model.provider,
-      model: model.id,
-      usage: {
-        input: 100,
-        output: 50,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 150,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
-      stopReason: "stop",
-      timestamp: Date.now(),
-    },
-  ];
-}
-
-function authController(): GatewayProviderAuthController {
+function configuredAuthController(): GatewayProviderAuthController {
   const auth: ApiKeyAuth = {
     name: "test",
-    resolve: async () => undefined,
+    async resolve({ credential }) {
+      return credential?.type === "api_key" && credential.key
+        ? {
+            auth: { apiKey: credential.key },
+            env: { [GATEWAY_RESOLVED_ROOT_ENV]: "https://gateway.example.test" },
+            source: "test credential",
+          }
+        : undefined;
+    },
   };
   return {
     auth,
     bind: vi.fn(),
     clear: vi.fn(),
     getActiveCwd: vi.fn(() => undefined),
-    hasConfiguredCredential: vi.fn(async () => false),
-    resolveRuntimeAuth: vi.fn(async () => undefined),
+    hasConfiguredCredential: vi.fn(async () => true),
+    resolveRuntimeAuth: vi.fn(async () => ({
+      apiKey: "test-key",
+      baseUrl: "https://gateway.example.test",
+      source: "test credential",
+    })),
+  };
+}
+
+async function createCompactionSession(
+  options: {
+    agentReplies?: Array<{
+      text: string;
+      stopReason: CompletedStopReason;
+      input?: number;
+      output?: number;
+    }>;
+    authenticated?: boolean;
+    throwingCompactionHook?: boolean;
+  } = {},
+) {
+  const cwd = mkdtempSync(path.join(tmpdir(), "sf-pi-gateway-compaction-"));
+  tempDirs.push(cwd);
+  const summarization = vi.fn((model: Model<Api>) => summaryStream(model));
+  let agentCall = 0;
+  const agent = vi.fn((model: Model<Api>) => {
+    const reply = options.agentReplies?.[agentCall++] ?? {
+      text: "[agent response]",
+      stopReason: "stop" as const,
+      input: 100,
+      output: 20,
+    };
+    return summaryStream(model, reply.text, reply.stopReason, {
+      input: reply.input ?? 100,
+      output: reply.output ?? 20,
+    });
+  });
+  const dispatch = (model: Model<Api>, context: Context) =>
+    context.systemPrompt?.includes("test agent prompt") ? agent(model) : summarization(model);
+  const simple = vi.fn(dispatch);
+  const full = vi.fn(dispatch);
+  const streams: GatewayStreamImplementations = {
+    anthropicFull: full as GatewayStreamImplementations["anthropicFull"],
+    chatFull: full as GatewayStreamImplementations["chatFull"],
+    responsesFull: full as GatewayStreamImplementations["responsesFull"],
+    anthropicSimple: simple as GatewayStreamImplementations["anthropicSimple"],
+    chatSimple: simple as GatewayStreamImplementations["chatSimple"],
+    responsesSimple: simple as GatewayStreamImplementations["responsesSimple"],
+  };
+  const fetchers: GatewayFetchers = {
+    modelIds: vi.fn(async () => ({ ids: ["example-chat-model"], filteredIds: [] })),
+    modelInfo: vi.fn(async () => ({})),
+  };
+  const runtime = createGatewayProviderRuntime({
+    authController: configuredAuthController(),
+    fetchers,
+    streams,
+  });
+  const credentials = new InMemoryCredentialStore();
+  await credentials.modify(PROVIDER_NAME, async () => ({
+    type: "api_key",
+    key: "test-key",
+  }));
+  const modelRuntime = await ModelRuntime.create({
+    credentials,
+    modelsStore: new InMemoryModelsStore(),
+    modelsPath: null,
+    allowModelNetwork: false,
+  });
+  modelRuntime.registerNativeProvider(runtime.provider);
+  const refresh = await modelRuntime.refresh({ providers: [PROVIDER_NAME], force: true });
+  expect(refresh.errors.size).toBe(0);
+  const model = modelRuntime.getModel(PROVIDER_NAME, "example-chat-model");
+  expect(model).toBeDefined();
+  if (!model) throw new Error("Expected refreshed Gateway model");
+  if (options.authenticated === false) {
+    await credentials.delete(PROVIDER_NAME);
+  }
+
+  const sessionManager = SessionManager.inMemory(cwd);
+  sessionManager.appendMessage({
+    role: "user",
+    content: [{ type: "text", text: "old context ".repeat(80) }],
+    timestamp: Date.now() - 3,
+  });
+  sessionManager.appendMessage({
+    role: "assistant",
+    content: [{ type: "text", text: "old response" }],
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: {
+      input: 300,
+      output: 20,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 320,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: Date.now() - 2,
+  });
+  sessionManager.appendMessage({
+    role: "user",
+    content: [{ type: "text", text: "recent request" }],
+    timestamp: Date.now() - 1,
+  });
+
+  const settingsManager = SettingsManager.inMemory({
+    compaction: { enabled: true, reserveTokens: 1_024, keepRecentTokens: 1 },
+    retry: { enabled: false, maxRetries: 0, baseDelayMs: 0 },
+  });
+  const resourceLoader = new DefaultResourceLoader({
+    cwd,
+    agentDir: cwd,
+    settingsManager,
+    noExtensions: true,
+    noSkills: true,
+    noPromptTemplates: true,
+    noThemes: true,
+    noContextFiles: true,
+    systemPromptOverride: () => "test agent prompt",
+    extensionFactories: options.throwingCompactionHook
+      ? [
+          {
+            name: "throwing-compaction-hook",
+            factory: (pi) => {
+              pi.on("session_before_compact", () => {
+                throw new Error("custom compaction hook failed");
+              });
+            },
+          },
+        ]
+      : [],
+  });
+  await resourceLoader.reload();
+  const { session } = await createAgentSession({
+    cwd,
+    agentDir: cwd,
+    model,
+    noTools: "all",
+    modelRuntime,
+    settingsManager,
+    resourceLoader,
+    sessionManager,
+  });
+  return {
+    session,
+    summarization,
+    agent,
+    restoreCredential: () =>
+      credentials.modify(PROVIDER_NAME, async () => ({ type: "api_key", key: "test-key" })),
   };
 }
 
 describe("Pi compaction → complete Gateway Provider", () => {
-  it("runs the registered Gateway streamSimple implementation", async () => {
-    let calls = 0;
-    let systemPrompt: string | undefined;
-    const simple = (model: Model<Api>, context: Context) => {
-      calls += 1;
-      systemPrompt = context.systemPrompt;
-      return summaryStream(model);
-    };
-    const full = (model: Model<Api>) => summaryStream(model);
-    const streams: GatewayStreamImplementations = {
-      anthropicFull: full as GatewayStreamImplementations["anthropicFull"],
-      chatFull: full as GatewayStreamImplementations["chatFull"],
-      responsesFull: full as GatewayStreamImplementations["responsesFull"],
-      anthropicSimple: simple as GatewayStreamImplementations["anthropicSimple"],
-      chatSimple: simple as GatewayStreamImplementations["chatSimple"],
-      responsesSimple: simple as GatewayStreamImplementations["responsesSimple"],
-    };
-    const runtime = createGatewayProviderRuntime({ authController: authController(), streams });
-    const model = {
-      ...toProviderModelConfig("example-chat-model"),
-      provider: PROVIDER_NAME,
-      baseUrl: "https://gateway.invalid/v1",
-    } as Model<Api>;
+  it("compacts an in-memory AgentSession through registered Gateway auth and dispatch", async () => {
+    const { session, summarization } = await createCompactionSession();
 
-    const summary = await generateSummary(
-      userMessages(model),
-      model,
-      8_192,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      runtime.provider.streamSimple.bind(runtime.provider),
-    );
+    try {
+      const result = await session.compact();
 
-    expect(calls).toBe(1);
-    expect(systemPrompt).toBeTruthy();
-    expect(summary).toBe("[gateway summary]");
+      expect(result.summary).toContain("[gateway summary]");
+      expect(summarization).toHaveBeenCalledOnce();
+      expect(session.sessionManager.getBranch().at(-1)).toMatchObject({
+        type: "compaction",
+        summary: expect.stringContaining("[gateway summary]"),
+      });
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it("falls back to built-in Gateway compaction when a custom compaction hook throws", async () => {
+    const { session, summarization } = await createCompactionSession({
+      throwingCompactionHook: true,
+    });
+
+    try {
+      await expect(session.compact()).resolves.toMatchObject({
+        summary: expect.stringContaining("[gateway summary]"),
+      });
+      expect(summarization).toHaveBeenCalledOnce();
+      expect(session.sessionManager.getBranch().at(-1)).toMatchObject({ type: "compaction" });
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it("leaves the session uncompacted and recoverable when Gateway auth is unavailable", async () => {
+    const { session, restoreCredential } = await createCompactionSession({ authenticated: false });
+    const entriesBefore = session.sessionManager.getEntries().length;
+
+    try {
+      await expect(session.compact()).rejects.toThrow(
+        "Summarization failed: Provider is not configured: sf-llm-gateway",
+      );
+      expect(session.sessionManager.getEntries()).toHaveLength(entriesBefore);
+      expect(session.sessionManager.getEntries().some((entry) => entry.type === "compaction")).toBe(
+        false,
+      );
+
+      await restoreCredential();
+      await expect(session.compact()).resolves.toMatchObject({
+        summary: expect.stringContaining("[gateway summary]"),
+      });
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it("compacts and retries once when a Gateway response is truncated below its output limit", async () => {
+    const { session, summarization, agent } = await createCompactionSession({
+      agentReplies: [
+        { text: "[truncated]", stopReason: "length", input: 7_000, output: 10 },
+        { text: "[recovered response]", stopReason: "stop", input: 500, output: 20 },
+      ],
+    });
+
+    try {
+      await session.prompt("continue after the truncated response");
+
+      expect(agent).toHaveBeenCalledTimes(2);
+      expect(summarization).toHaveBeenCalled();
+      expect(session.sessionManager.getBranch()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "compaction",
+            summary: expect.stringContaining("[gateway summary]"),
+          }),
+        ]),
+      );
+      expect(session.messages.at(-1)).toMatchObject({
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "text", text: "[recovered response]" }],
+      });
+    } finally {
+      session.dispose();
+    }
   });
 });


### PR DESCRIPTION
## What this PR does

Repaints SF DevBar from Pi's post-compaction context state and adds exact-Pi behavior proofs for gateway-backed manual and overflow compaction.

## Why

After a successful compaction, SF DevBar could keep showing the pre-compaction percentage until another assistant turn. The existing gateway compaction test also bypassed `AgentSession`, `ModelRuntime` auth resolution, and overflow recovery, so it could not protect the failure paths observed during investigation.

## How

- Handle `session_compact` in SF DevBar and immediately repaint from `ctx.getContextUsage()`; Pi reports the percentage as unknown until fresh post-compaction usage exists.
- Replace the direct summarizer-only gateway test with in-memory `AgentSession` proofs covering authenticated manual compaction, throwing-hook fallback, missing-auth recovery without a checkpoint, and truncated-response compact-and-retry.
- Update the SF DevBar manifest and regenerate its catalog/runtime documentation projections.

## Checklist

- [x] I ran `npm run validate` locally, or I listed the focused checks I ran below
- [x] The affected README already documents the intended post-compaction `unknown` state; no prose change was needed
- [x] I added or updated tests
- [x] I regenerated the catalog (`npm run generate-catalog`) after touching `manifest.json`
- [x] This PR is non-breaking

## Security and public-surface checklist

- [x] I considered whether this adds or changes a high-value durable mutation exposed through an LLM-callable tool; it does not
- [x] No high-value mutation is introduced
- [x] Execution intent flags are not treated as approval
- [x] No headless confirm-class operation is introduced
- [x] No operator auto-approve behavior is introduced
- [x] Public docs, examples, tests, comments, and diagnostics contain only generic fixtures and no private identifiers or endpoints
- [x] No new env vars, settings, provider labels, or non-generic examples are introduced

## Validation performed

- `npm exec vitest -- run extensions/sf-devbar/tests/compaction-repaint.test.ts extensions/sf-devbar/tests/runtime-facts.test.ts extensions/sf-devbar/tests/smoke.test.ts extensions/sf-llm-gateway/tests/compaction-routes-through-gateway.test.ts extensions/sf-llm-gateway/tests/provider-auth.test.ts extensions/sf-llm-gateway/tests/provider.test.ts extensions/sf-llm-gateway/tests/lifecycle.test.ts` — 7 files, 46 tests passed
- `npm run test:runtime-surface` — 30 tests passed
- `npm run validate:ci` — 559 files passed, 1 skipped; 3,995 tests passed, 39 skipped; all catalog, docs, formatting, type, ESLint, architecture, lifecycle, and artifact checks passed
- `npm run lint` — passed

## Notes for reviewers

This intentionally does not add an SF Pi custom summarizer or change gateway access-state behavior. Legacy external compaction-extension compatibility, explicit `no-default-models` handling, and Pi's no-op/proactive-reserve UX remain separate follow-up decisions.
