### PR TITLE
feat(gateway): add configurable compaction model

### DIFF
--- a/catalog/index.json
+++ b/catalog/index.json
@@ -653,6 +653,7 @@
     "tools": [],
     "events": [
       "session_start",
+      "session_before_compact",
       "turn_end",
       "model_select",
       "after_provider_response",
@@ -661,10 +662,12 @@
     "docs": {
       "intentGroup": "Personalize pi",
       "editingRules": "AGENTS.md",
-      "summary": "Complete Pi Provider for the Salesforce LLM Gateway. Pi-owned credential persistence and model storage, authenticated dynamic discovery with offline cache restore, provider-neutral mixed-API dispatch, explicit refresh, diagnostics, and usage status.",
+      "summary": "Complete Pi Provider for the Salesforce LLM Gateway. Pi-owned credential persistence and model storage, authenticated dynamic discovery with offline cache restore, provider-neutral mixed-API dispatch, optional dedicated-model compaction, explicit refresh, diagnostics, and usage status.",
       "primaryFiles": [
         "index.ts",
         "lib/provider.ts",
+        "lib/compaction.ts",
+        "lib/compaction-settings.ts",
         "lib/transport.ts",
         "lib/models.ts",
         "lib/config.ts",
@@ -673,19 +676,21 @@
       "stateFiles": [
         "~/.pi/agent/auth.json (Pi-owned API-key credential + default non-secret URL)",
         "<globalAgentDir>/sf-llm-gateway.json (non-secret settings)",
-        "<globalAgentDir>/sf-llm-gateway/* (monthly usage and diagnostic state)"
+        "<globalAgentDir>/sf-llm-gateway/* (monthly usage and diagnostic state)",
+        "Pi settings.json sfPi.compaction.model (global/project compaction model preference)"
       ],
       "safety": [
         "API-key input uses SF Pi's shared fixed-mask component and never enters Pi's visible stock prompt.",
         "Pi alone persists/removes active credentials; setup and import paths write no secrets.",
         "Extension config stores only non-secret settings; credentials remain Pi-owned.",
+        "Dedicated compaction accepts only authenticated sf-llm-gateway models, never changes the chat model, and falls back to Pi.",
         "Pi's settings.json is mutated through pi-settings.ts helpers with race-aware reads."
       ]
     },
     "entry": "extensions/sf-llm-gateway/index.ts",
     "hasReadme": true,
     "hasTests": true,
-    "srcLoc": 8928
+    "srcLoc": 9376
   },
   {
     "id": "sf-lsp",
@@ -859,7 +864,7 @@
     "entry": "extensions/sf-pi-manager/index.ts",
     "hasReadme": true,
     "hasTests": true,
-    "srcLoc": 4614
+    "srcLoc": 4615
   },
   {
     "id": "sf-skills",

--- a/catalog/registry.ts
+++ b/catalog/registry.ts
@@ -205,7 +205,7 @@ export const SF_PI_REGISTRY: readonly SfPiExtension[] = [
     defaultEnabled: true,
     commands: ["/sf-llm-gateway"],
     providers: ["sf-llm-gateway"],
-    events: ["session_start","turn_end","model_select","after_provider_response","session_shutdown"],
+    events: ["session_start","session_before_compact","turn_end","model_select","after_provider_response","session_shutdown"],
     configurable: true,
     getConfigPanel: async () => {
       const mod = await import("../extensions/sf-llm-gateway/lib/config-panel.ts");

--- a/catalog/types.ts
+++ b/catalog/types.ts
@@ -5,7 +5,7 @@
  * Hand-maintained. The generated registry.ts re-exports these types.
  */
 import type { Focusable, TUI } from "@earendil-works/pi-tui";
-import type { Theme } from "@earendil-works/pi-coding-agent";
+import type { ExtensionCommandContext, Theme } from "@earendil-works/pi-coding-agent";
 
 // -------------------------------------------------------------------------------------------------
 // Config panel protocol
@@ -19,7 +19,8 @@ import type { Theme } from "@earendil-works/pi-coding-agent";
  * It receives input when focused and calls `done()` when the user is finished.
  *
  * Panels that need to signal a reload (e.g. after enabling/disabling a provider)
- * return `{ needsReload: true }` via the done callback.
+ * return `{ needsReload: true }` via the done callback. The optional command
+ * context lets dynamic panels inspect current runtime state without capturing it.
  */
 export type ConfigPanelResult = {
   needsReload?: boolean;
@@ -31,6 +32,7 @@ export type ConfigPanelFactory = (
   scope: "global" | "project",
   done: (result: ConfigPanelResult | undefined) => void,
   tui?: TUI,
+  ctx?: ExtensionCommandContext,
 ) => Focusable;
 
 // -------------------------------------------------------------------------------------------------

--- a/docs/extensions/sf-llm-gateway.md
+++ b/docs/extensions/sf-llm-gateway.md
@@ -10,7 +10,7 @@ editLink: false
 
 ## What it does
 
-Complete Pi Provider for the Salesforce LLM Gateway. Pi-owned credential persistence and model storage, authenticated dynamic discovery with offline cache restore, provider-neutral mixed-API dispatch, explicit refresh, diagnostics, and usage status.
+Complete Pi Provider for the Salesforce LLM Gateway. Pi-owned credential persistence and model storage, authenticated dynamic discovery with offline cache restore, provider-neutral mixed-API dispatch, optional dedicated-model compaction, explicit refresh, diagnostics, and usage status.
 
 ## Start
 
@@ -33,6 +33,7 @@ Open its Manager detail or change its package state with:
 - API-key input uses SF Pi's shared fixed-mask component and never enters Pi's visible stock prompt.
 - Pi alone persists/removes active credentials; setup and import paths write no secrets.
 - Extension config stores only non-secret settings; credentials remain Pi-owned.
+- Dedicated compaction accepts only authenticated sf-llm-gateway models, never changes the chat model, and falls back to Pi.
 - Pi's settings.json is mutated through pi-settings.ts helpers with race-aware reads.
 
 ## Exact reference
@@ -48,7 +49,7 @@ Open its Manager detail or change its package state with:
 - **Commands:** `/sf-llm-gateway`
 - **LLM tools:** _none_
 - **Providers:** `sf-llm-gateway`
-- **Events/hooks:** `session_start`, `turn_end`, `model_select`, `after_provider_response`, `session_shutdown`
+- **Events/hooks:** `session_start`, `session_before_compact`, `turn_end`, `model_select`, `after_provider_response`, `session_shutdown`
 
 </details>
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -110,6 +110,7 @@ Jump to an extension's Troubleshooting section to see the full fix. This index i
 - Usage or throttle status is stale
 - Thinking changes after a model switch
 - Saved and environment credentials conflict
+- The dedicated compaction model falls back to the active model
 
 **[SF Agent Script](./extensions/sf-agentscript.md#troubleshooting)**
 

--- a/extensions/sf-llm-gateway/AGENTS.md
+++ b/extensions/sf-llm-gateway/AGENTS.md
@@ -23,6 +23,9 @@ Repo-level rules still apply; see root `AGENTS.md`.
 | Discovery metadata + family inference          | `lib/models.ts`                    |
 | Complete Provider + model discovery            | `lib/provider.ts`                  |
 | Provider auth + session context                | `lib/provider-auth.ts`             |
+| Dedicated compaction policy                    | `lib/compaction.ts`                |
+| Scoped compaction preference                   | `lib/compaction-settings.ts`       |
+| Manager compaction model picker                | `lib/compaction-model-picker.ts`   |
 | Masked API-key input                           | `common secure credential prompt`  |
 | HTTP transport (OpenAI-compat + Anthropic)     | `lib/transport.ts`                 |
 | Monthly usage / key info / health fetcher      | `lib/monthly-usage.ts`             |
@@ -80,9 +83,12 @@ copy.
    the non-secret saved/env configuration view; request, status, usage, token,
    and readiness paths use `authController.resolveRuntimeAuth()` for the
    effective endpoint and credential. Never require both views to contain a URL.
-7. **Setup is persistence-only.** Saving endpoint or scope overrides performs no
-   discovery, usage probe, enable, disable, or model selection. Keep network and
+7. **Setup is persistence-only.** Saving endpoint, scope, or compaction preferences performs no
+   discovery, usage probe, enable, disable, or chat-model selection. Keep network and
    lifecycle intent on the existing explicit actions.
+8. **Dedicated compaction is opt-in and bounded.** `active` leaves Pi's compaction untouched.
+   Explicit selections must come from the authenticated Gateway catalog, never change the chat
+   model, preserve summary usage/file context, and fall back to Pi without exposing provider errors.
 
 ## Command handler pattern
 

--- a/extensions/sf-llm-gateway/README.md
+++ b/extensions/sf-llm-gateway/README.md
@@ -70,6 +70,39 @@ All gateway model costs are reported as zero because provider billing is handled
 outside Pi. Usage status uses the available user/key information endpoints and
 does not claim a lifetime counter when the service cannot prove one.
 
+## Compaction Model Preference
+
+Pi's native `compaction.enabled` setting remains the only switch for automatic
+threshold and overflow compaction. Manual `/compact` remains available whether
+automatic compaction is enabled or disabled.
+
+SF Pi can optionally use a dedicated authenticated Gateway model for manual,
+threshold, and overflow summaries without changing the active conversation
+model. The shipped default is `active`, which leaves compaction entirely with
+Pi's active model. Configure the preference from the Gateway Manager setup panel
+or in global/project Pi settings:
+
+```json
+{
+  "compaction": { "enabled": true },
+  "sfPi": {
+    "compaction": {
+      "model": "sf-llm-gateway/claude-sonnet-5"
+    }
+  }
+}
+```
+
+Set the model to `active` to restore Pi's built-in behavior. The Manager picker
+uses the currently authenticated Gateway catalog rather than a hardcoded list;
+for example, a user may choose a quality-oriented Sonnet model or a
+latency-oriented Flash model when those entries are available to their
+credential. If the configured model is unavailable, too small for the summary
+request, returns an incomplete response, or fails, SF Pi warns once and falls
+back to Pi's active-model compaction. Conversation data never leaves the
+configured Gateway because this preference accepts only `sf-llm-gateway/*`
+models.
+
 ## Diagnostics
 
 `/sf-llm-gateway doctor` checks URL shape, credential readiness, model discovery,
@@ -126,6 +159,11 @@ level. Review Pi's `/thinking` choice and `defaultThinkingLevel` setting.
 
 **Saved and environment credentials conflict:** Pi's saved credential wins. Use
 native login to replace it or remove the stale environment fallback.
+
+**The dedicated compaction model falls back to the active model:** Refresh the
+Gateway catalog and reopen the setup panel. Confirm that the saved model is
+still available to the current credential and has enough context capacity for
+the session being compacted.
 
 ## File Structure
 

--- a/extensions/sf-llm-gateway/index.ts
+++ b/extensions/sf-llm-gateway/index.ts
@@ -28,6 +28,9 @@
  *                                       pasted values.
  * - SF_LLM_GATEWAY_API_KEY             optional automation fallback. Normal users
  *                                       should authenticate through /login.
+ * - sfPi.compaction.model               optional global/project Pi preference.
+ *                                       `active` keeps Pi's built-in behavior;
+ *                                       sf-llm-gateway/<id> uses a dedicated model.
  *
  * Commands:
  * - /sf-llm-gateway                     open Manager detail page (UI) or text status (headless)
@@ -54,6 +57,7 @@
  *   after_provider_response     | model is gateway model + 2xx       | Clear any live throttle/upstream warning
  *   after_provider_response     | model is gateway model + 429       | Record throttle signal, footer shows ⚠ badge for 60s
  *   after_provider_response     | model is gateway model + 5xx       | Record upstream signal, footer shows ⚠ badge for 60s
+ *   session_before_compact      | dedicated model configured          | Summarize through that model or fall back to Pi
  *   session_shutdown            | —                                  | Cancel credential UI; clear cwd/auth/footer/provider state
  *   /command (no args)          | interactive UI                     | Open Manager detail page
  *   /command (no args)          | no UI                              | Print text status report
@@ -69,6 +73,7 @@
  * - Start at the extension entry point to see the runtime spine
  * - Then read provider registration/discovery in lib/provider.ts
  * - Provider auth + session context live in lib/provider-auth.ts
+ * - Dedicated-model compaction lives in lib/compaction.ts and lib/compaction-settings.ts
  * - Monthly usage caching lives in lib/monthly-usage.ts
  * - Pi settings mutations live in lib/pi-settings.ts
  * - Footer/status formatting lives in lib/status.ts
@@ -133,6 +138,8 @@ import {
   writeSettings,
 } from "./lib/pi-settings.ts";
 import { gatewayProviderRuntime } from "./lib/provider.ts";
+import { handleGatewayCompaction } from "./lib/compaction.ts";
+import { buildGatewayCompactionModelOptions } from "./lib/compaction-settings.ts";
 import { fetchGatewayDoctorReport, formatGatewayDoctorReport } from "./lib/doctor.ts";
 import { countTokens, estimateSpend, formatTokenReport } from "./lib/token-counter.ts";
 import { buildOnboardingUrl } from "./lib/onboarding.ts";
@@ -295,6 +302,8 @@ export default function sfLlmGatewayInternalExtension(pi: ExtensionAPI) {
   // Register one complete Pi Provider. Pi owns auth application, provider-scoped
   // model persistence, refresh coordination, and API dispatch from this point on.
   pi.registerProvider(gatewayProviderRuntime.provider);
+
+  pi.on("session_before_compact", handleGatewayCompaction);
 
   // Contribute to the aggregated `/sf-pi doctor` view. The standalone
   // `/sf-llm-gateway doctor` command keeps using
@@ -467,8 +476,13 @@ function gatewayManagerAction(
       ? {
           // Setup owns local non-secret persistence only. Enable, disable, and
           // network refresh remain explicit Manager actions.
-          createPanel: (theme, cwd, scope, done) =>
-            new GatewayConfigPanelComponent(theme, scope, cwd, done, { closeOnSave: true }),
+          createPanel: (theme, cwd, scope, done, ctx) =>
+            new GatewayConfigPanelComponent(theme, scope, cwd, done, {
+              closeOnSave: true,
+              compactionModels: buildGatewayCompactionModelOptions(
+                ctx.modelRegistry.getAvailable(),
+              ),
+            }),
         }
       : {}),
   };

--- a/extensions/sf-llm-gateway/lib/compaction-model-picker.ts
+++ b/extensions/sf-llm-gateway/lib/compaction-model-picker.ts
@@ -1,0 +1,107 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/** State and persistence for the Gateway compaction-model field in Manager settings. */
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import {
+  ACTIVE_COMPACTION_MODEL,
+  readScopedCompactionModel,
+  writeScopedCompactionModel,
+  type CompactionSettingsScope,
+  type GatewayCompactionModel,
+  type GatewayCompactionModelOption,
+} from "./compaction-settings.ts";
+
+export type CompactionModelChoice = "inherit" | GatewayCompactionModel;
+export type CompactionModelChoiceOption = {
+  value: CompactionModelChoice;
+  label: string;
+  description: string;
+};
+
+export class GatewayCompactionModelPicker {
+  private selected: CompactionModelChoice;
+  private persisted: CompactionModelChoice;
+  private readonly options: readonly CompactionModelChoiceOption[];
+
+  constructor(
+    private readonly cwd: string,
+    private readonly scope: CompactionSettingsScope,
+    models: readonly GatewayCompactionModelOption[],
+  ) {
+    const scoped = readScopedCompactionModel(cwd, scope);
+    this.selected = scoped ?? (scope === "project" ? "inherit" : ACTIVE_COMPACTION_MODEL);
+    this.persisted = this.selected;
+    this.options = buildChoices(scope, this.selected, models);
+  }
+
+  current(): CompactionModelChoiceOption {
+    return (
+      this.options.find((option) => option.value === this.selected) ??
+      this.options[0] ?? {
+        value: ACTIVE_COMPACTION_MODEL,
+        label: "Active conversation model",
+        description: "Use Pi's active-model compaction.",
+      }
+    );
+  }
+
+  renderRows(theme: Theme, focused: boolean): string[] {
+    const option = this.current();
+    const fieldPrefix = focused ? theme.fg("accent", "▶") : theme.fg("dim", "•");
+    const valuePrefix = focused ? theme.fg("accent", "→") : theme.fg("dim", " ");
+    return [
+      `${fieldPrefix} ${theme.fg(focused ? "accent" : "text", "Compaction model")}`,
+      `  ${valuePrefix} ${theme.fg(focused ? "accent" : "text", option.label)}`,
+      `   ${theme.fg("muted", option.description)}`,
+      `   ${theme.fg("dim", "Applies to manual, threshold, and overflow compaction without changing the chat model.")}`,
+    ];
+  }
+
+  cycle(direction: -1 | 1): void {
+    const currentIndex = this.options.findIndex((option) => option.value === this.selected);
+    const safeIndex = currentIndex >= 0 ? currentIndex : 0;
+    const nextIndex = (safeIndex + direction + this.options.length) % this.options.length;
+    this.selected = this.options[nextIndex]?.value ?? this.selected;
+  }
+
+  isDirty(): boolean {
+    return this.selected !== this.persisted;
+  }
+
+  persist(): void {
+    const model = this.selected === "inherit" ? undefined : this.selected;
+    writeScopedCompactionModel(this.cwd, this.scope, model);
+    this.selected = model ?? (this.scope === "project" ? "inherit" : ACTIVE_COMPACTION_MODEL);
+    this.persisted = this.selected;
+  }
+}
+
+function buildChoices(
+  scope: CompactionSettingsScope,
+  current: CompactionModelChoice,
+  models: readonly GatewayCompactionModelOption[],
+): CompactionModelChoiceOption[] {
+  const options: CompactionModelChoiceOption[] = [];
+  if (scope === "project") {
+    options.push({
+      value: "inherit",
+      label: "Inherit global preference",
+      description: "Use the global SF Pi compaction model preference.",
+    });
+  }
+  options.push({
+    value: ACTIVE_COMPACTION_MODEL,
+    label: "Active conversation model",
+    description: "Use Pi's built-in active-model compaction.",
+  });
+  options.push(...models);
+
+  if (!options.some((option) => option.value === current)) {
+    options.push({
+      value: current,
+      label: current.split("/").at(-1) ?? current,
+      description: "Saved model is not currently available; runtime will fall back to Pi.",
+    });
+  }
+
+  return [...new Map(options.map((option) => [option.value, option])).values()];
+}

--- a/extensions/sf-llm-gateway/lib/compaction-settings.ts
+++ b/extensions/sf-llm-gateway/lib/compaction-settings.ts
@@ -1,0 +1,123 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/** Scoped SF Pi preference for choosing a dedicated Gateway compaction model. */
+import type { Api, Model } from "@earendil-works/pi-ai";
+import {
+  globalSettingsPath,
+  projectSettingsPath,
+  readJsonFile,
+  writeJsonFile,
+} from "../../../lib/common/sf-pi-settings.ts";
+import { PROVIDER_NAME } from "./config.ts";
+
+export const ACTIVE_COMPACTION_MODEL = "active" as const;
+export type GatewayCompactionModel =
+  typeof ACTIVE_COMPACTION_MODEL | `${typeof PROVIDER_NAME}/${string}`;
+export type CompactionSettingsScope = "global" | "project";
+export type CompactionSettingsSource = CompactionSettingsScope | "default";
+
+export interface GatewayCompactionModelOption {
+  value: GatewayCompactionModel;
+  label: string;
+  description: string;
+}
+
+export interface EffectiveCompactionSettings {
+  model: GatewayCompactionModel;
+  source: CompactionSettingsSource;
+  globalModel?: GatewayCompactionModel;
+  projectModel?: GatewayCompactionModel;
+}
+
+export function buildGatewayCompactionModelOptions(
+  models: readonly Pick<Model<Api>, "provider" | "id" | "name" | "contextWindow" | "maxTokens">[],
+): GatewayCompactionModelOption[] {
+  return models
+    .filter((model) => model.provider === PROVIDER_NAME)
+    .map((model) => ({
+      value: `${PROVIDER_NAME}/${model.id}` as GatewayCompactionModel,
+      label: model.name.replace(/^\[SF LLM Gateway\]\s*/u, "") || model.id,
+      description: `${formatTokenCapacity(model.contextWindow)} context · ${formatTokenCapacity(model.maxTokens)} output`,
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+}
+
+export function normalizeCompactionModel(value: unknown): GatewayCompactionModel | undefined {
+  if (value === ACTIVE_COMPACTION_MODEL) return ACTIVE_COMPACTION_MODEL;
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim();
+  const prefix = `${PROVIDER_NAME}/`;
+  return normalized.startsWith(prefix) && normalized.length > prefix.length
+    ? (normalized as GatewayCompactionModel)
+    : undefined;
+}
+
+export function readEffectiveCompactionSettings(
+  cwd: string,
+  globalSettingsFile: string = globalSettingsPath(),
+): EffectiveCompactionSettings {
+  const globalModel = readScopedCompactionModel(cwd, "global", globalSettingsFile);
+  const projectModel = readScopedCompactionModel(cwd, "project", globalSettingsFile);
+  if (projectModel) return { model: projectModel, source: "project", globalModel, projectModel };
+  if (globalModel) return { model: globalModel, source: "global", globalModel, projectModel };
+  return { model: ACTIVE_COMPACTION_MODEL, source: "default", globalModel, projectModel };
+}
+
+export function readScopedCompactionModel(
+  cwd: string,
+  scope: CompactionSettingsScope,
+  globalSettingsFile: string = globalSettingsPath(),
+): GatewayCompactionModel | undefined {
+  const root = readJsonFile(settingsPathForScope(cwd, scope, globalSettingsFile));
+  const sfPi = nestedRecord(root, "sfPi");
+  const compaction = nestedRecord(sfPi, "compaction");
+  return normalizeCompactionModel(compaction.model);
+}
+
+export function writeScopedCompactionModel(
+  cwd: string,
+  scope: CompactionSettingsScope,
+  model: GatewayCompactionModel | undefined,
+  globalSettingsFile: string = globalSettingsPath(),
+): void {
+  const filePath = settingsPathForScope(cwd, scope, globalSettingsFile);
+  const root = readJsonFile(filePath);
+  const nextRoot = { ...root };
+  const sfPi = { ...nestedRecord(nextRoot, "sfPi") };
+  const compaction = { ...nestedRecord(sfPi, "compaction") };
+
+  if (model) compaction.model = model;
+  else delete compaction.model;
+
+  if (Object.keys(compaction).length > 0) sfPi.compaction = compaction;
+  else delete sfPi.compaction;
+
+  if (Object.keys(sfPi).length > 0) nextRoot.sfPi = sfPi;
+  else delete nextRoot.sfPi;
+
+  writeJsonFile(filePath, nextRoot);
+}
+
+export function settingsPathForScope(
+  cwd: string,
+  scope: CompactionSettingsScope,
+  globalSettingsFile: string = globalSettingsPath(),
+): string {
+  return scope === "project" ? projectSettingsPath(cwd) : globalSettingsFile;
+}
+
+function formatTokenCapacity(tokens: number): string {
+  if (tokens >= 1_000_000) return `${formatCapacityNumber(tokens / 1_000_000)}M`;
+  if (tokens >= 1_000) return `${formatCapacityNumber(tokens / 1_000)}K`;
+  return String(tokens);
+}
+
+function formatCapacityNumber(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1).replace(/\.0$/u, "");
+}
+
+function nestedRecord(parent: Record<string, unknown>, key: string): Record<string, unknown> {
+  const value = parent[key];
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}

--- a/extensions/sf-llm-gateway/lib/compaction.ts
+++ b/extensions/sf-llm-gateway/lib/compaction.ts
@@ -1,0 +1,186 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/** Dedicated-model compaction policy for SF LLM Gateway. */
+import { contentText, uuidv7, type Api, type Model } from "@earendil-works/pi-ai";
+import {
+  convertToLlm,
+  serializeConversation,
+  type ExtensionContext,
+  type SessionBeforeCompactEvent,
+} from "@earendil-works/pi-coding-agent";
+import {
+  ACTIVE_COMPACTION_MODEL,
+  readEffectiveCompactionSettings,
+  type EffectiveCompactionSettings,
+} from "./compaction-settings.ts";
+import { PROVIDER_NAME } from "./config.ts";
+
+const MAX_SUMMARY_TOKENS = 8_192;
+const CONTEXT_SAFETY_TOKENS = 4_096;
+const SUMMARY_SYSTEM_PROMPT =
+  "You are a context summarization assistant. Return only a structured checkpoint that another agent can use to continue the work.";
+const SUMMARY_FORMAT = `Use this exact structure:
+
+## Goal
+[Current objective]
+
+## Constraints & Preferences
+- [Requirements and constraints]
+
+## Progress
+### Done
+- [x] [Completed work]
+
+### In Progress
+- [ ] [Current work]
+
+### Blocked
+- [Current blockers]
+
+## Key Decisions
+- **[Decision]**: [Rationale]
+
+## Next Steps
+1. [Ordered next action]
+
+## Critical Context
+- [Exact paths, function names, errors, data, or references needed to continue]
+
+Keep every section concise. Preserve exact technical identifiers and error messages.`;
+
+export interface GatewayCompactionDependencies {
+  readSettings?: (cwd: string) => EffectiveCompactionSettings;
+}
+
+export async function handleGatewayCompaction(
+  event: SessionBeforeCompactEvent,
+  ctx: ExtensionContext,
+  dependencies: GatewayCompactionDependencies = {},
+) {
+  const preference = (dependencies.readSettings ?? readEffectiveCompactionSettings)(ctx.cwd);
+  if (preference.model === ACTIVE_COMPACTION_MODEL) return undefined;
+
+  const modelId = preference.model.slice(`${PROVIDER_NAME}/`.length);
+  const model = ctx.modelRegistry
+    .getAvailable()
+    .find((candidate) => candidate.provider === PROVIDER_NAME && candidate.id === modelId);
+  if (!model) {
+    warnFallback(ctx, `Configured compaction model ${preference.model} is unavailable.`);
+    return undefined;
+  }
+
+  const prompt = buildSummaryPrompt(event);
+  const maxTokens = Math.min(MAX_SUMMARY_TOKENS, positiveMaxTokens(model));
+  if (!fitsContext(model, prompt, maxTokens)) {
+    warnFallback(
+      ctx,
+      `Configured compaction model ${preference.model} cannot fit this checkpoint request.`,
+    );
+    return undefined;
+  }
+
+  try {
+    const response = await ctx.modelRegistry.complete(
+      model,
+      {
+        systemPrompt: SUMMARY_SYSTEM_PROMPT,
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: prompt }],
+            timestamp: Date.now(),
+          },
+        ],
+      },
+      {
+        maxTokens,
+        signal: event.signal,
+        cacheRetention: "none",
+        sessionId: uuidv7(),
+      },
+    );
+
+    if (event.signal.aborted || response.stopReason === "aborted") return { cancel: true };
+    if (response.stopReason !== "stop") {
+      warnFallback(ctx, `Configured compaction model ${preference.model} did not finish normally.`);
+      return undefined;
+    }
+
+    const summaryText = contentText(response.content).trim();
+    if (!summaryText) {
+      warnFallback(
+        ctx,
+        `Configured compaction model ${preference.model} returned an empty summary.`,
+      );
+      return undefined;
+    }
+
+    const { readFiles, modifiedFiles } = computeFileLists(event.preparation.fileOps);
+    const summary = `${summaryText}${formatFileOperations(readFiles, modifiedFiles)}`;
+    return {
+      compaction: {
+        summary,
+        firstKeptEntryId: event.preparation.firstKeptEntryId,
+        tokensBefore: event.preparation.tokensBefore,
+        usage: response.usage,
+        details: { readFiles, modifiedFiles },
+      },
+    };
+  } catch {
+    if (event.signal.aborted) return { cancel: true };
+    warnFallback(
+      ctx,
+      `Configured compaction model ${preference.model} failed. Run /sf-llm-gateway doctor.`,
+    );
+    return undefined;
+  }
+}
+
+function buildSummaryPrompt(event: SessionBeforeCompactEvent): string {
+  const messages = [
+    ...event.preparation.messagesToSummarize,
+    ...event.preparation.turnPrefixMessages,
+  ];
+  const conversation = serializeConversation(convertToLlm(messages));
+  const previousSummary = event.preparation.previousSummary
+    ? `\n\n<previous-summary>\n${event.preparation.previousSummary}\n</previous-summary>`
+    : "";
+  const customInstructions = event.customInstructions
+    ? `\n\nAdditional focus:\n${event.customInstructions}`
+    : "";
+  return `<conversation>\n${conversation}\n</conversation>${previousSummary}\n\n${SUMMARY_FORMAT}${customInstructions}`;
+}
+
+function positiveMaxTokens(model: Model<Api>): number {
+  return model.maxTokens > 0 ? model.maxTokens : MAX_SUMMARY_TOKENS;
+}
+
+function fitsContext(model: Model<Api>, prompt: string, maxTokens: number): boolean {
+  if (model.contextWindow <= 0) return true;
+  const estimatedInputTokens = Math.ceil((SUMMARY_SYSTEM_PROMPT.length + prompt.length) / 4);
+  return estimatedInputTokens + maxTokens + CONTEXT_SAFETY_TOKENS <= model.contextWindow;
+}
+
+function computeFileLists(fileOps: SessionBeforeCompactEvent["preparation"]["fileOps"]): {
+  readFiles: string[];
+  modifiedFiles: string[];
+} {
+  const modified = new Set([...fileOps.edited, ...fileOps.written]);
+  return {
+    readFiles: [...fileOps.read].filter((file) => !modified.has(file)).sort(),
+    modifiedFiles: [...modified].sort(),
+  };
+}
+
+function formatFileOperations(readFiles: string[], modifiedFiles: string[]): string {
+  const sections: string[] = [];
+  if (readFiles.length > 0) sections.push(`<read-files>\n${readFiles.join("\n")}\n</read-files>`);
+  if (modifiedFiles.length > 0) {
+    sections.push(`<modified-files>\n${modifiedFiles.join("\n")}\n</modified-files>`);
+  }
+  return sections.length > 0 ? `\n\n${sections.join("\n\n")}` : "";
+}
+
+function warnFallback(ctx: ExtensionContext, reason: string): void {
+  if (!ctx.hasUI) return;
+  ctx.ui.notify(`${reason} Falling back to Pi's active-model compaction.`, "warning");
+}

--- a/extensions/sf-llm-gateway/lib/config-panel.ts
+++ b/extensions/sf-llm-gateway/lib/config-panel.ts
@@ -28,12 +28,25 @@ import {
   projectGatewayConfigPath,
 } from "./config.ts";
 import { getTextViewport, type SetupOverlayState, getSetupOverlayState } from "./setup-overlay.ts";
+import {
+  buildGatewayCompactionModelOptions,
+  settingsPathForScope,
+  type GatewayCompactionModelOption,
+} from "./compaction-settings.ts";
+import { GatewayCompactionModelPicker } from "./compaction-model-picker.ts";
 
 // -------------------------------------------------------------------------------------------------
 // Types
 // -------------------------------------------------------------------------------------------------
 
-type PanelField = "baseUrl" | "exclusiveScope" | "open-token" | "import-claude" | "save" | "cancel";
+type PanelField =
+  | "baseUrl"
+  | "exclusiveScope"
+  | "compactionModel"
+  | "open-token"
+  | "import-claude"
+  | "save"
+  | "cancel";
 
 type GatewayConfigPanelResult = ConfigPanelResult & {
   gatewayAction?: "open-token" | "import-claude" | "save";
@@ -47,6 +60,8 @@ type ConfigPanelOptions = {
   externalActions?: boolean;
   /** Close after save and return a gatewayAction to the host. Manager-hosted settings save in place. */
   closeOnSave?: boolean;
+  /** Authenticated Gateway catalog projected by the Manager-hosted settings action. */
+  compactionModels?: readonly GatewayCompactionModelOption[];
 };
 
 // -------------------------------------------------------------------------------------------------
@@ -141,6 +156,7 @@ export class GatewayConfigPanelComponent implements Focusable {
   private savedExclusiveScopeMode: ExclusiveScopeMode;
   private persistedBaseUrl: string;
   private persistedExclusiveScopeMode: ExclusiveScopeMode;
+  private readonly compactionModelPicker: GatewayCompactionModelPicker;
   private baseUrlCursor: number;
   private errorMessage: string | null = null;
   private savedMessage: string | null = null;
@@ -159,6 +175,7 @@ export class GatewayConfigPanelComponent implements Focusable {
     this.focusOrder = [
       "baseUrl",
       "exclusiveScope",
+      "compactionModel",
       ...(options.externalActions ? (["open-token", "import-claude"] as const) : []),
       "save",
       "cancel",
@@ -170,6 +187,11 @@ export class GatewayConfigPanelComponent implements Focusable {
     );
     this.persistedBaseUrl = this.savedBaseUrl;
     this.persistedExclusiveScopeMode = this.savedExclusiveScopeMode;
+    this.compactionModelPicker = new GatewayCompactionModelPicker(
+      cwd,
+      scope,
+      options.compactionModels ?? [],
+    );
     this.baseUrlCursor = this.savedBaseUrl.length;
   }
 
@@ -189,6 +211,12 @@ export class GatewayConfigPanelComponent implements Focusable {
 
     if (focus === "exclusiveScope") {
       if (this.handleExclusiveScopeInput(data)) {
+        return;
+      }
+    }
+
+    if (focus === "compactionModel") {
+      if (this.handleCompactionModelInput(data)) {
         return;
       }
     }
@@ -301,7 +329,6 @@ export class GatewayConfigPanelComponent implements Focusable {
     );
     lines.push(pad(""));
 
-    // Scoped model mode field
     lines.push(pad(` ${this.renderFieldLabel("exclusiveScope", "Scoped model scope fallback")}`));
     lines.push(pad(`   ${this.renderExclusiveScopeField()}`));
     lines.push(
@@ -346,7 +373,13 @@ export class GatewayConfigPanelComponent implements Focusable {
     }
     lines.push(pad(""));
 
-    // Action buttons
+    const compactionRows = this.compactionModelPicker.renderRows(
+      theme,
+      this.currentFocus() === "compactionModel",
+    );
+    for (const row of compactionRows) lines.push(pad(` ${row}`));
+    lines.push(pad(""));
+
     lines.push(pad(` ${theme.fg("muted", "Actions")}`));
     if (this.options.externalActions) {
       lines.push(
@@ -360,7 +393,6 @@ export class GatewayConfigPanelComponent implements Focusable {
     );
     lines.push(pad(""));
 
-    // Status / error line
     if (this.errorMessage) {
       lines.push(pad(` ${theme.fg("error", `⚠ ${this.errorMessage}`)}`));
     } else if (this.savedMessage) {
@@ -375,7 +407,12 @@ export class GatewayConfigPanelComponent implements Focusable {
         ),
       );
     }
-    lines.push(pad(` ${theme.fg("dim", `Save target: ${saveTarget}`)}`));
+    lines.push(pad(` ${theme.fg("dim", `Gateway save target: ${saveTarget}`)}`));
+    lines.push(
+      pad(
+        ` ${theme.fg("dim", `Compaction preference: ${settingsPathForScope(this.cwd, this.scope)}`)}`,
+      ),
+    );
 
     return lines;
   }
@@ -386,8 +423,6 @@ export class GatewayConfigPanelComponent implements Focusable {
   }
 
   invalidate(): void {}
-
-  // --- Private helpers ---
 
   private currentFocus(): PanelField {
     // focusIndex is kept in range by the moveFocus helpers, so focusOrder
@@ -495,6 +530,21 @@ export class GatewayConfigPanelComponent implements Focusable {
     return false;
   }
 
+  private handleCompactionModelInput(data: string): boolean {
+    const direction = isLeftKey(data)
+      ? -1
+      : isRightKey(data) ||
+          matchesKey(data, "space") ||
+          matchesKey(data, "enter") ||
+          matchesKey(data, "return")
+        ? 1
+        : 0;
+    if (direction === 0) return false;
+    this.compactionModelPicker.cycle(direction);
+    this.errorMessage = null;
+    return true;
+  }
+
   private cycleExclusiveScopeMode(direction: -1 | 1): void {
     const modes: ExclusiveScopeMode[] = ["inherit", "exclusive", "additive"];
     const currentIndex = modes.indexOf(this.savedExclusiveScopeMode);
@@ -576,6 +626,10 @@ export class GatewayConfigPanelComponent implements Focusable {
       this.cycleExclusiveScopeMode(1);
       return;
     }
+    if (focus === "compactionModel") {
+      this.compactionModelPicker.cycle(1);
+      return;
+    }
     if (focus === "cancel") {
       this.closePanel();
       return;
@@ -609,7 +663,6 @@ export class GatewayConfigPanelComponent implements Focusable {
       return;
     }
 
-    // Save the config
     const configPath =
       this.scope === "project" ? projectGatewayConfigPath(this.cwd) : globalGatewayConfigPath();
     const saved = readGatewaySavedConfig(configPath);
@@ -627,7 +680,9 @@ export class GatewayConfigPanelComponent implements Focusable {
       saved.exclusiveScope = savedExclusiveScope;
     }
 
-    const changed = this.isDirty(normalizedSavedBaseUrl);
+    const gatewayChanged = this.isGatewayDirty(normalizedSavedBaseUrl);
+    const compactionChanged = this.compactionModelPicker.isDirty();
+    const changed = gatewayChanged || compactionChanged;
 
     if (!changed && !this.options.closeOnSave) {
       this.savedMessage = "No changes to save.";
@@ -635,7 +690,12 @@ export class GatewayConfigPanelComponent implements Focusable {
       return;
     }
 
-    writeGatewaySavedConfig(configPath, saved);
+    if (gatewayChanged) {
+      writeGatewaySavedConfig(configPath, saved);
+    }
+    if (compactionChanged) {
+      this.compactionModelPicker.persist();
+    }
     this.markSaved(normalizedSavedBaseUrl, savedExclusiveScope);
 
     if (this.options.closeOnSave) {
@@ -643,8 +703,12 @@ export class GatewayConfigPanelComponent implements Focusable {
       return;
     }
 
-    this.reloadRequired = true;
-    this.savedMessage = "Saved gateway settings.";
+    this.reloadRequired = this.reloadRequired || gatewayChanged;
+    this.savedMessage = gatewayChanged
+      ? compactionChanged
+        ? "Saved gateway and compaction settings."
+        : "Saved gateway settings."
+      : "Saved compaction preference.";
     this.errorMessage = null;
   }
 
@@ -666,6 +730,10 @@ export class GatewayConfigPanelComponent implements Focusable {
   }
 
   private isDirty(normalizedSavedBaseUrl: string | undefined): boolean {
+    return this.isGatewayDirty(normalizedSavedBaseUrl) || this.compactionModelPicker.isDirty();
+  }
+
+  private isGatewayDirty(normalizedSavedBaseUrl: string | undefined): boolean {
     const draftBaseUrl = normalizedSavedBaseUrl ?? "";
     return (
       draftBaseUrl !== (normalizeBaseUrl(this.persistedBaseUrl) ?? "") ||
@@ -723,6 +791,8 @@ export class GatewayConfigPanelComponent implements Focusable {
 // -------------------------------------------------------------------------------------------------
 
 /** Convention export name used by the catalog generator. */
-export const createConfigPanel: ConfigPanelFactory = (theme, cwd, scope, done) => {
-  return new GatewayConfigPanelComponent(theme, scope, cwd, done);
+export const createConfigPanel: ConfigPanelFactory = (theme, cwd, scope, done, _tui, ctx) => {
+  return new GatewayConfigPanelComponent(theme, scope, cwd, done, {
+    compactionModels: buildGatewayCompactionModelOptions(ctx?.modelRegistry.getAvailable() ?? []),
+  });
 };

--- a/extensions/sf-llm-gateway/lib/status.ts
+++ b/extensions/sf-llm-gateway/lib/status.ts
@@ -6,6 +6,7 @@
  * runtime event handlers makes the main index easier to scan and easier to test.
  */
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { readEffectiveCompactionSettings } from "./compaction-settings.ts";
 import {
   API_KEY_ENV,
   PROVIDER_NAME,
@@ -83,6 +84,7 @@ export function buildStatusReport(
   const config = getGatewayConfig(ctx.cwd);
   const savedConfig = getMergedSavedGatewayConfig(ctx.cwd);
   const savedScope = getSavedExclusiveScopeStatus(ctx.cwd);
+  const compaction = readEffectiveCompactionSettings(ctx.cwd);
   const activeModel = getActiveModelDefinition(ctx.model?.id, state.discovery?.modelIds);
   const contextUsage = ctx.getContextUsage();
   const discovery = state.discovery;
@@ -108,6 +110,7 @@ export function buildStatusReport(
     `Effective scoped model mode: ${config.exclusiveScope ? "exclusive (gateway-only scoped models)" : "additive (preserve existing scoped models)"}`,
     `Active model: ${ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : "none"}`,
     `Active SF model: ${activeModel ? activeModel.name : "no"}`,
+    `Compaction model: ${compaction.model} (${compaction.source})`,
     "Thinking selection: managed by Pi/user settings",
     `Context usage: ${contextUsage ? `${formatTokens(contextUsage.tokens)} / ${formatTokens(contextUsage.contextWindow)}` : "unknown"}`,
     `Monthly usage: ${formatMonthlyUsageReportLine(state.monthlyUsage, state.monthlyUsageError)}`,

--- a/extensions/sf-llm-gateway/manifest.json
+++ b/extensions/sf-llm-gateway/manifest.json
@@ -10,6 +10,7 @@
   "providers": ["sf-llm-gateway"],
   "events": [
     "session_start",
+    "session_before_compact",
     "turn_end",
     "model_select",
     "after_provider_response",
@@ -18,10 +19,12 @@
   "docs": {
     "intentGroup": "Personalize pi",
     "editingRules": "AGENTS.md",
-    "summary": "Complete Pi Provider for the Salesforce LLM Gateway. Pi-owned credential persistence and model storage, authenticated dynamic discovery with offline cache restore, provider-neutral mixed-API dispatch, explicit refresh, diagnostics, and usage status.",
+    "summary": "Complete Pi Provider for the Salesforce LLM Gateway. Pi-owned credential persistence and model storage, authenticated dynamic discovery with offline cache restore, provider-neutral mixed-API dispatch, optional dedicated-model compaction, explicit refresh, diagnostics, and usage status.",
     "primaryFiles": [
       "index.ts",
       "lib/provider.ts",
+      "lib/compaction.ts",
+      "lib/compaction-settings.ts",
       "lib/transport.ts",
       "lib/models.ts",
       "lib/config.ts",
@@ -30,12 +33,14 @@
     "stateFiles": [
       "~/.pi/agent/auth.json (Pi-owned API-key credential + default non-secret URL)",
       "<globalAgentDir>/sf-llm-gateway.json (non-secret settings)",
-      "<globalAgentDir>/sf-llm-gateway/* (monthly usage and diagnostic state)"
+      "<globalAgentDir>/sf-llm-gateway/* (monthly usage and diagnostic state)",
+      "Pi settings.json sfPi.compaction.model (global/project compaction model preference)"
     ],
     "safety": [
       "API-key input uses SF Pi's shared fixed-mask component and never enters Pi's visible stock prompt.",
       "Pi alone persists/removes active credentials; setup and import paths write no secrets.",
       "Extension config stores only non-secret settings; credentials remain Pi-owned.",
+      "Dedicated compaction accepts only authenticated sf-llm-gateway models, never changes the chat model, and falls back to Pi.",
       "Pi's settings.json is mutated through pi-settings.ts helpers with race-aware reads."
     ]
   }

--- a/extensions/sf-llm-gateway/tests/compaction-policy.test.ts
+++ b/extensions/sf-llm-gateway/tests/compaction-policy.test.ts
@@ -1,0 +1,224 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ExtensionContext, SessionBeforeCompactEvent } from "@earendil-works/pi-coding-agent";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { handleGatewayCompaction } from "../lib/compaction.ts";
+
+const SONNET = {
+  id: "claude-sonnet-5",
+  name: "Claude Sonnet 5",
+  provider: "sf-llm-gateway",
+  api: "anthropic-messages",
+  baseUrl: "https://gateway.invalid",
+  reasoning: true,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 1_000_000,
+  maxTokens: 128_000,
+} as Model<"anthropic-messages">;
+
+const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+const tempDirs: string[] = [];
+let agentDir: string;
+
+beforeEach(() => {
+  agentDir = tempDir();
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+});
+
+afterEach(() => {
+  if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+  else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function tempDir(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "sf-pi-compaction-policy-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function event(reason: SessionBeforeCompactEvent["reason"] = "manual") {
+  return {
+    type: "session_before_compact",
+    reason,
+    willRetry: reason === "overflow",
+    customInstructions: undefined,
+    signal: new AbortController().signal,
+    branchEntries: [],
+    preparation: {
+      messagesToSummarize: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "old conversation" }],
+          timestamp: Date.now(),
+        },
+      ],
+      turnPrefixMessages: [],
+      tokensBefore: 1_000,
+      firstKeptEntryId: "kept-entry",
+      previousSummary: undefined,
+      fileOps: { read: new Set<string>(), written: new Set<string>(), edited: new Set<string>() },
+      isSplitTurn: false,
+      settings: { enabled: true, reserveTokens: 16_384, keepRecentTokens: 20_000 },
+    },
+  } as unknown as SessionBeforeCompactEvent;
+}
+
+function context(cwd: string) {
+  const getAvailable = vi.fn(() => [] as Model<Api>[]);
+  const complete = vi.fn();
+  const notify = vi.fn();
+  return {
+    ctx: {
+      cwd,
+      hasUI: true,
+      modelRegistry: { getAvailable, complete },
+      ui: { notify },
+    } as unknown as ExtensionContext,
+    getAvailable,
+    complete,
+    notify,
+  };
+}
+
+describe("Gateway compaction policy", () => {
+  it("leaves compaction to Pi when the effective preference is active", async () => {
+    const cwd = tempDir();
+    const { ctx, getAvailable, complete } = context(cwd);
+
+    await expect(
+      handleGatewayCompaction(event(), ctx, {
+        readSettings: () => ({ model: "active", source: "default" }),
+      }),
+    ).resolves.toBeUndefined();
+    expect(getAvailable).not.toHaveBeenCalled();
+    expect(complete).not.toHaveBeenCalled();
+  });
+
+  it("falls back when the configured model is not currently available", async () => {
+    const cwd = tempDir();
+    const { ctx, complete, notify } = context(cwd);
+
+    await expect(
+      handleGatewayCompaction(event(), ctx, {
+        readSettings: () => ({
+          model: "sf-llm-gateway/claude-sonnet-5",
+          source: "global",
+        }),
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(complete).not.toHaveBeenCalled();
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining("Falling back to Pi's active-model compaction"),
+      "warning",
+    );
+  });
+
+  it("falls back before calling a configured model whose context is too small", async () => {
+    const cwd = tempDir();
+    const tiny = { ...SONNET, id: "tiny-summary-model", contextWindow: 128, maxTokens: 64 };
+    const { ctx, getAvailable, complete, notify } = context(cwd);
+    getAvailable.mockReturnValue([tiny]);
+
+    await expect(
+      handleGatewayCompaction(event(), ctx, {
+        readSettings: () => ({
+          model: "sf-llm-gateway/tiny-summary-model",
+          source: "global",
+        }),
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(complete).not.toHaveBeenCalled();
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("cannot fit"), "warning");
+  });
+
+  it("falls back with a public-safe warning when the configured model call fails", async () => {
+    const cwd = tempDir();
+    const { ctx, getAvailable, complete, notify } = context(cwd);
+    getAvailable.mockReturnValue([SONNET]);
+    complete.mockRejectedValue(new Error("private endpoint and credential detail"));
+
+    await expect(
+      handleGatewayCompaction(event(), ctx, {
+        readSettings: () => ({
+          model: "sf-llm-gateway/claude-sonnet-5",
+          source: "global",
+        }),
+      }),
+    ).resolves.toBeUndefined();
+
+    const warning = String(notify.mock.calls[0]?.[0] ?? "");
+    expect(warning).toContain("Falling back to Pi's active-model compaction");
+    expect(warning).not.toContain("private endpoint");
+  });
+
+  it.each(["manual", "threshold", "overflow"] as const)(
+    "creates a checkpoint with the configured Gateway model for %s compaction",
+    async (reason) => {
+      const cwd = tempDir();
+      const { ctx, getAvailable, complete } = context(cwd);
+      getAvailable.mockReturnValue([SONNET]);
+      complete.mockResolvedValue({
+        role: "assistant",
+        content: [{ type: "text", text: "## Goal\nPreserve the active task." }],
+        api: SONNET.api,
+        provider: SONNET.provider,
+        model: SONNET.id,
+        usage: {
+          input: 100,
+          output: 20,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 120,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop",
+        timestamp: Date.now(),
+      });
+
+      const compactionEvent = event(reason);
+      compactionEvent.preparation.fileOps.read.add("src/read-only.ts");
+      compactionEvent.preparation.fileOps.read.add("src/changed.ts");
+      compactionEvent.preparation.fileOps.edited.add("src/changed.ts");
+      const result = await handleGatewayCompaction(compactionEvent, ctx, {
+        readSettings: () => ({
+          model: "sf-llm-gateway/claude-sonnet-5",
+          source: "global",
+          globalModel: "sf-llm-gateway/claude-sonnet-5",
+        }),
+      });
+
+      expect(getAvailable).toHaveBeenCalledOnce();
+      expect(complete).toHaveBeenCalledWith(
+        SONNET,
+        expect.objectContaining({ messages: expect.any(Array) }),
+        expect.objectContaining({
+          maxTokens: 8_192,
+          cacheRetention: "none",
+          sessionId: expect.any(String),
+          signal: expect.any(AbortSignal),
+        }),
+      );
+      expect(result).toMatchObject({
+        compaction: {
+          summary: expect.stringMatching(
+            /## Goal[\s\S]*<read-files>\nsrc\/read-only\.ts\n<\/read-files>[\s\S]*<modified-files>\nsrc\/changed\.ts\n<\/modified-files>/u,
+          ),
+          firstKeptEntryId: "kept-entry",
+          tokensBefore: 1_000,
+          usage: { totalTokens: 120 },
+          details: {
+            readFiles: ["src/read-only.ts"],
+            modifiedFiles: ["src/changed.ts"],
+          },
+        },
+      });
+    },
+  );
+});

--- a/extensions/sf-llm-gateway/tests/compaction-routes-through-gateway.test.ts
+++ b/extensions/sf-llm-gateway/tests/compaction-routes-through-gateway.test.ts
@@ -8,6 +8,7 @@ import {
   createAgentSession,
   DefaultResourceLoader,
   ModelRuntime,
+  type ExtensionAPI,
   SessionManager,
   SettingsManager,
 } from "@earendil-works/pi-coding-agent";
@@ -22,6 +23,8 @@ import {
   type Model,
 } from "@earendil-works/pi-ai";
 import { PROVIDER_NAME } from "../lib/config.ts";
+import { handleGatewayCompaction } from "../lib/compaction.ts";
+import { writeScopedCompactionModel } from "../lib/compaction-settings.ts";
 import {
   GATEWAY_RESOLVED_ROOT_ENV,
   type GatewayProviderAuthController,
@@ -116,11 +119,15 @@ async function createCompactionSession(
     }>;
     authenticated?: boolean;
     throwingCompactionHook?: boolean;
+    dedicatedCompactionModel?: boolean;
   } = {},
 ) {
   const cwd = mkdtempSync(path.join(tmpdir(), "sf-pi-gateway-compaction-"));
   tempDirs.push(cwd);
   const summarization = vi.fn((model: Model<Api>) => summaryStream(model));
+  const dedicatedSummarization = vi.fn((model: Model<Api>) =>
+    summaryStream(model, "[dedicated summary]"),
+  );
   let agentCall = 0;
   const agent = vi.fn((model: Model<Api>) => {
     const reply = options.agentReplies?.[agentCall++] ?? {
@@ -134,8 +141,12 @@ async function createCompactionSession(
       output: reply.output ?? 20,
     });
   });
-  const dispatch = (model: Model<Api>, context: Context) =>
-    context.systemPrompt?.includes("test agent prompt") ? agent(model) : summarization(model);
+  const dispatch = (model: Model<Api>, context: Context) => {
+    if (model.id === "claude-sonnet-5") return dedicatedSummarization(model);
+    return context.systemPrompt?.includes("test agent prompt")
+      ? agent(model)
+      : summarization(model);
+  };
   const simple = vi.fn(dispatch);
   const full = vi.fn(dispatch);
   const streams: GatewayStreamImplementations = {
@@ -147,7 +158,10 @@ async function createCompactionSession(
     responsesSimple: simple as GatewayStreamImplementations["responsesSimple"],
   };
   const fetchers: GatewayFetchers = {
-    modelIds: vi.fn(async () => ({ ids: ["example-chat-model"], filteredIds: [] })),
+    modelIds: vi.fn(async () => ({
+      ids: ["example-chat-model", ...(options.dedicatedCompactionModel ? ["claude-sonnet-5"] : [])],
+      filteredIds: [],
+    })),
     modelInfo: vi.fn(async () => ({})),
   };
   const runtime = createGatewayProviderRuntime({
@@ -174,6 +188,9 @@ async function createCompactionSession(
   if (!model) throw new Error("Expected refreshed Gateway model");
   if (options.authenticated === false) {
     await credentials.delete(PROVIDER_NAME);
+  }
+  if (options.dedicatedCompactionModel) {
+    writeScopedCompactionModel(cwd, "project", "sf-llm-gateway/claude-sonnet-5");
   }
 
   const sessionManager = SessionManager.inMemory(cwd);
@@ -209,6 +226,20 @@ async function createCompactionSession(
     compaction: { enabled: true, reserveTokens: 1_024, keepRecentTokens: 1 },
     retry: { enabled: false, maxRetries: 0, baseDelayMs: 0 },
   });
+  const extensionFactories: Array<(pi: ExtensionAPI) => void> = [];
+  if (options.throwingCompactionHook) {
+    extensionFactories.push((pi) => {
+      pi.on("session_before_compact", () => {
+        throw new Error("custom compaction hook failed");
+      });
+    });
+  }
+  if (options.dedicatedCompactionModel) {
+    extensionFactories.push((pi) => {
+      pi.on("session_before_compact", handleGatewayCompaction);
+    });
+  }
+
   const resourceLoader = new DefaultResourceLoader({
     cwd,
     agentDir: cwd,
@@ -219,18 +250,7 @@ async function createCompactionSession(
     noThemes: true,
     noContextFiles: true,
     systemPromptOverride: () => "test agent prompt",
-    extensionFactories: options.throwingCompactionHook
-      ? [
-          {
-            name: "throwing-compaction-hook",
-            factory: (pi) => {
-              pi.on("session_before_compact", () => {
-                throw new Error("custom compaction hook failed");
-              });
-            },
-          },
-        ]
-      : [],
+    extensionFactories,
   });
   await resourceLoader.reload();
   const { session } = await createAgentSession({
@@ -246,6 +266,7 @@ async function createCompactionSession(
   return {
     session,
     summarization,
+    dedicatedSummarization,
     agent,
     restoreCredential: () =>
       credentials.modify(PROVIDER_NAME, async () => ({ type: "api_key", key: "test-key" })),
@@ -265,6 +286,26 @@ describe("Pi compaction → complete Gateway Provider", () => {
         type: "compaction",
         summary: expect.stringContaining("[gateway summary]"),
       });
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it("uses a configured dedicated Gateway model without changing the active chat model", async () => {
+    const { session, summarization, dedicatedSummarization } = await createCompactionSession({
+      dedicatedCompactionModel: true,
+    });
+
+    try {
+      const activeModel = session.model;
+      await expect(session.compact()).resolves.toMatchObject({
+        summary: expect.stringContaining("[dedicated summary]"),
+      });
+
+      expect(dedicatedSummarization).toHaveBeenCalledOnce();
+      expect(summarization).not.toHaveBeenCalled();
+      expect(session.model).toBe(activeModel);
+      expect(session.model?.id).toBe("example-chat-model");
     } finally {
       session.dispose();
     }

--- a/extensions/sf-llm-gateway/tests/compaction-settings.test.ts
+++ b/extensions/sf-llm-gateway/tests/compaction-settings.test.ts
@@ -1,0 +1,128 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  ACTIVE_COMPACTION_MODEL,
+  buildGatewayCompactionModelOptions,
+  readEffectiveCompactionSettings,
+  writeScopedCompactionModel,
+} from "../lib/compaction-settings.ts";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function tempDir(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "sf-pi-compaction-settings-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("gateway compaction settings", () => {
+  it("defaults to the active Pi model and persists an explicit global gateway model", () => {
+    const cwd = tempDir();
+    const globalSettings = path.join(tempDir(), "settings.json");
+
+    expect(readEffectiveCompactionSettings(cwd, globalSettings)).toMatchObject({
+      model: ACTIVE_COMPACTION_MODEL,
+      source: "default",
+    });
+
+    writeScopedCompactionModel(cwd, "global", "sf-llm-gateway/claude-sonnet-5", globalSettings);
+
+    expect(readEffectiveCompactionSettings(cwd, globalSettings)).toMatchObject({
+      model: "sf-llm-gateway/claude-sonnet-5",
+      source: "global",
+    });
+    expect(JSON.parse(readFileSync(globalSettings, "utf8"))).toMatchObject({
+      sfPi: { compaction: { model: "sf-llm-gateway/claude-sonnet-5" } },
+    });
+  });
+
+  it("builds a dynamic picker from available Gateway models only", () => {
+    expect(
+      buildGatewayCompactionModelOptions([
+        {
+          provider: "sf-llm-gateway",
+          id: "claude-sonnet-5",
+          name: "[SF LLM Gateway] Claude Sonnet 5",
+          contextWindow: 1_000_000,
+          maxTokens: 128_000,
+        },
+        {
+          provider: "sf-llm-gateway",
+          id: "gemini-2.5-flash",
+          name: "[SF LLM Gateway] Gemini 2.5 Flash",
+          contextWindow: 1_000_000,
+          maxTokens: 65_536,
+        },
+        {
+          provider: "openai",
+          id: "gpt-5-mini",
+          name: "GPT-5 Mini",
+          contextWindow: 400_000,
+          maxTokens: 128_000,
+        },
+      ] as never),
+    ).toEqual([
+      {
+        value: "sf-llm-gateway/claude-sonnet-5",
+        label: "Claude Sonnet 5",
+        description: "1M context · 128K output",
+      },
+      {
+        value: "sf-llm-gateway/gemini-2.5-flash",
+        label: "Gemini 2.5 Flash",
+        description: "1M context · 65.5K output",
+      },
+    ]);
+  });
+
+  it("preserves unrelated Pi settings when writing and clearing the preference", () => {
+    const cwd = tempDir();
+    const globalSettings = path.join(tempDir(), "settings.json");
+    writeFileSync(
+      globalSettings,
+      `${JSON.stringify(
+        {
+          theme: "dark",
+          compaction: { enabled: false },
+          sfPi: { display: { profile: "compact" } },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    writeScopedCompactionModel(cwd, "global", "sf-llm-gateway/gemini-2.5-flash", globalSettings);
+    writeScopedCompactionModel(cwd, "global", undefined, globalSettings);
+
+    expect(JSON.parse(readFileSync(globalSettings, "utf8"))).toEqual({
+      theme: "dark",
+      compaction: { enabled: false },
+      sfPi: { display: { profile: "compact" } },
+    });
+  });
+
+  it("lets a project select active-model compaction or inherit the global model", () => {
+    const cwd = tempDir();
+    const globalSettings = path.join(tempDir(), "settings.json");
+    writeScopedCompactionModel(cwd, "global", "sf-llm-gateway/claude-sonnet-5", globalSettings);
+
+    writeScopedCompactionModel(cwd, "project", ACTIVE_COMPACTION_MODEL, globalSettings);
+    expect(readEffectiveCompactionSettings(cwd, globalSettings)).toMatchObject({
+      model: ACTIVE_COMPACTION_MODEL,
+      source: "project",
+    });
+
+    writeScopedCompactionModel(cwd, "project", undefined, globalSettings);
+    expect(readEffectiveCompactionSettings(cwd, globalSettings)).toMatchObject({
+      model: "sf-llm-gateway/claude-sonnet-5",
+      source: "global",
+    });
+  });
+});

--- a/extensions/sf-llm-gateway/tests/config-panel-manager.test.ts
+++ b/extensions/sf-llm-gateway/tests/config-panel-manager.test.ts
@@ -4,9 +4,10 @@ import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { Theme } from "@earendil-works/pi-coding-agent";
-import { GatewayConfigPanelComponent } from "../lib/config-panel.ts";
+import type { ExtensionCommandContext, Theme } from "@earendil-works/pi-coding-agent";
+import { createConfigPanel, GatewayConfigPanelComponent } from "../lib/config-panel.ts";
 import { BASE_URL_ENV, projectGatewayConfigPath, readGatewaySavedConfig } from "../lib/config.ts";
+import { readEffectiveCompactionSettings } from "../lib/compaction-settings.ts";
 
 const PI_AGENT_ENV = "PI_CODING_AGENT_DIR";
 const originalAgentDir = process.env[PI_AGENT_ENV];
@@ -53,13 +54,67 @@ describe("GatewayConfigPanelComponent Manager contract", () => {
     expect(text).not.toContain("Saved API key");
   });
 
+  it("offers available Gateway models as scoped compaction preferences", () => {
+    const getAvailable = vi.fn(() => [
+      {
+        provider: "sf-llm-gateway",
+        id: "claude-sonnet-5",
+        name: "[SF LLM Gateway] Claude Sonnet 5",
+        contextWindow: 1_000_000,
+        maxTokens: 128_000,
+      },
+    ]);
+    const panel = createConfigPanel(theme, tempProjectDir, "project", vi.fn(), undefined, {
+      modelRegistry: { getAvailable },
+    } as unknown as ExtensionCommandContext) as GatewayConfigPanelComponent;
+
+    panel.handleInput("\x1b[B"); // base URL -> scoped model mode
+    panel.handleInput("\x1b[B"); // scoped model mode -> compaction model
+    panel.handleInput("\x1b[C"); // inherit -> active
+    panel.handleInput("\x1b[C"); // active -> Claude Sonnet 5
+    const text = panel.renderContent(100).join("\n");
+
+    expect(text).toContain("Compaction model");
+    expect(text).toContain("Claude Sonnet 5");
+    expect(text).toContain("1M context · 128K output");
+  });
+
+  it("saves a project compaction model without changing the active chat model", () => {
+    const done = vi.fn();
+    const panel = new GatewayConfigPanelComponent(theme, "project", tempProjectDir, done, {
+      compactionModels: [
+        {
+          value: "sf-llm-gateway/claude-sonnet-5",
+          label: "Claude Sonnet 5",
+          description: "1M context · 128K output",
+        },
+      ],
+    });
+
+    panel.handleInput("\x1b[B"); // base URL -> scoped model mode
+    panel.handleInput("\x1b[B"); // scoped model mode -> compaction model
+    panel.handleInput("\x1b[C"); // inherit -> active
+    panel.handleInput("\x1b[C"); // active -> Claude Sonnet 5
+    panel.handleInput("\x1b[B"); // compaction model -> Save
+    panel.handleInput("\r");
+
+    expect(readEffectiveCompactionSettings(tempProjectDir)).toMatchObject({
+      model: "sf-llm-gateway/claude-sonnet-5",
+      source: "project",
+    });
+    expect(panel.renderContent(100).join("\n")).not.toContain("Reload required");
+    panel.handleInput("\x1b");
+    expect(done).toHaveBeenCalledWith(undefined);
+  });
+
   it("saves non-secret settings", () => {
     const done = vi.fn();
     const panel = new GatewayConfigPanelComponent(theme, "project", tempProjectDir, done);
 
     panel.handleInput("https://gateway.example.com/v1");
     panel.handleInput("\r"); // base URL -> scoped model mode
-    panel.handleInput("\x1b[B"); // scoped model mode -> Save
+    panel.handleInput("\x1b[B"); // scoped model mode -> compaction model
+    panel.handleInput("\x1b[B"); // compaction model -> Save
     panel.handleInput("\r"); // Save in place
 
     expect(done).not.toHaveBeenCalled();
@@ -82,7 +137,8 @@ describe("GatewayConfigPanelComponent Manager contract", () => {
     });
 
     panel.handleInput("\x1b[B"); // base URL -> scoped model mode
-    panel.handleInput("\x1b[B"); // scoped model mode -> Open token page
+    panel.handleInput("\x1b[B"); // scoped model mode -> compaction model
+    panel.handleInput("\x1b[B"); // compaction model -> Open token page
     panel.handleInput("\r");
 
     expect(done).toHaveBeenCalledWith({
@@ -96,7 +152,8 @@ describe("GatewayConfigPanelComponent Manager contract", () => {
     const panel = new GatewayConfigPanelComponent(theme, "project", tempProjectDir, done);
 
     panel.handleInput("\x1b[B"); // base URL -> scoped model mode
-    panel.handleInput("\x1b[B"); // scoped model mode -> Save
+    panel.handleInput("\x1b[B"); // scoped model mode -> compaction model
+    panel.handleInput("\x1b[B"); // compaction model -> Save
     panel.handleInput("\r"); // Save in place
     panel.handleInput("\x1b");
 

--- a/extensions/sf-llm-gateway/tests/lifecycle.test.ts
+++ b/extensions/sf-llm-gateway/tests/lifecycle.test.ts
@@ -156,6 +156,15 @@ describe("gateway extension lifecycle", () => {
     vi.restoreAllMocks();
   });
 
+  it("registers the dedicated-model compaction policy hook", async () => {
+    const { default: extension } = await import("../index.ts");
+    const pi = makeFakePi();
+
+    extension(pi as never);
+
+    expect(pi.handlers.session_before_compact).toHaveLength(1);
+  });
+
   it("registers one complete native Provider", async () => {
     const { default: extension } = await import("../index.ts");
     const pi = makeFakePi();

--- a/extensions/sf-llm-gateway/tests/manager-setup.test.ts
+++ b/extensions/sf-llm-gateway/tests/manager-setup.test.ts
@@ -141,6 +141,48 @@ describe("Manager Gateway setup", () => {
     expect(readGatewaySavedConfig(configPath).enabled).toBe(false);
   });
 
+  it("projects the authenticated Gateway catalog into the compaction model picker", () => {
+    const cwd = tempDir("sf-pi-gateway-manager-compaction-");
+    const getAvailable = vi.fn(() => [
+      {
+        provider: PROVIDER_NAME,
+        id: "claude-sonnet-5",
+        name: "[SF LLM Gateway] Claude Sonnet 5",
+        contextWindow: 1_000_000,
+        maxTokens: 128_000,
+      },
+      {
+        provider: "openai",
+        id: "gpt-5-mini",
+        name: "GPT-5 Mini",
+        contextWindow: 400_000,
+        maxTokens: 128_000,
+      },
+    ]);
+    const ctx = {
+      cwd,
+      mode: "tui",
+      hasUI: true,
+      modelRegistry: { getAvailable },
+      ui: { notify: vi.fn(), setStatus: vi.fn() },
+    } as unknown as ExtensionCommandContext;
+    const setup = buildGatewayManagerActions({} as never).find((action) => action.id === "setup");
+    const panel = setup?.createPanel?.(theme, cwd, "project", vi.fn(), ctx, {
+      requestRender: vi.fn(),
+    } as unknown as TUI);
+    expect(panel).toBeDefined();
+    if (!panel) return;
+
+    panel.handleInput?.("\x1b[B"); // base URL -> scoped model mode
+    panel.handleInput?.("\x1b[B"); // scoped model mode -> compaction model
+    panel.handleInput?.("\x1b[C"); // inherit -> active
+    panel.handleInput?.("\x1b[C"); // active -> Claude Sonnet 5
+
+    expect(getAvailable).toHaveBeenCalledOnce();
+    expect(panel.renderContent?.(100).join("\n")).toContain("Claude Sonnet 5");
+    expect(panel.renderContent?.(100).join("\n")).not.toContain("GPT-5 Mini");
+  });
+
   it("persists settings without starting model or usage refresh work", async () => {
     const cwd = tempDir("sf-pi-gateway-manager-project-");
     const refresh = vi.fn(async () => undefined);
@@ -153,6 +195,7 @@ describe("Manager Gateway setup", () => {
         source: "Pi saved credential",
       })),
       getAll: () => [],
+      getAvailable: () => [],
       find: () => undefined,
     } as unknown as ModelRegistry;
     const ui = {
@@ -183,7 +226,8 @@ describe("Manager Gateway setup", () => {
     panel.focused = true;
     panel.handleInput?.("https://gateway.example.test/v1");
     panel.handleInput?.("\r"); // base URL -> scoped model mode
-    panel.handleInput?.("\x1b[B"); // scoped model mode -> primary Save action
+    panel.handleInput?.("\x1b[B"); // scoped model mode -> compaction model
+    panel.handleInput?.("\x1b[B"); // compaction model -> primary Save action
     panel.handleInput?.("\r");
     await Promise.resolve();
     await Promise.resolve();

--- a/extensions/sf-llm-gateway/tests/status.test.ts
+++ b/extensions/sf-llm-gateway/tests/status.test.ts
@@ -8,6 +8,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { API_KEY_ENV, BASE_URL_ENV } from "../lib/config.ts";
+import { writeScopedCompactionModel } from "../lib/compaction-settings.ts";
 
 const originalHomeEnv = process.env.HOME;
 const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
@@ -180,9 +181,12 @@ describe("buildFooterStatus", () => {
 describe("buildStatusReport", () => {
   it("shows discovery details", () => {
     process.env.HOME = makeTempDir("gateway-home-");
+    process.env.PI_CODING_AGENT_DIR = makeTempDir("gateway-agent-");
+    const cwd = makeTempDir("gateway-status-");
+    writeScopedCompactionModel(cwd, "project", "sf-llm-gateway/claude-sonnet-5");
 
     const ctx = {
-      cwd: makeTempDir("gateway-status-"),
+      cwd,
       model: { provider: "sf-llm-gateway", id: "example-native-message-model" },
       modelRegistry: {
         getProviderAuthStatus: () => ({ configured: true, source: "stored" }),
@@ -211,6 +215,7 @@ describe("buildStatusReport", () => {
     expect(report).toContain(
       "Effective scoped model mode: additive (preserve existing scoped models)",
     );
+    expect(report).toContain("Compaction model: sf-llm-gateway/claude-sonnet-5 (project)");
     expect(report).toContain("Model discovery: gateway");
     expect(report).toContain("Discovered models: 2");
   });

--- a/extensions/sf-pi-manager/lib/overlay.ts
+++ b/extensions/sf-pi-manager/lib/overlay.ts
@@ -700,6 +700,7 @@ export class SfPiOverlayComponent implements Focusable {
         this.returnToDetail();
       },
       this.tui,
+      this.commandCtx,
     ) as ConfigPanel;
   }
 

--- a/extensions/sf-pi-manager/tests/extension-details.test.ts
+++ b/extensions/sf-pi-manager/tests/extension-details.test.ts
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import path from "node:path";
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import {
@@ -279,6 +279,14 @@ describe("extension detail helpers", () => {
   });
 
   it("scrolls long settings pages with PageDown", async () => {
+    const commandCtx = {} as never;
+    const configFactory = vi.fn(() => ({
+      focused: false,
+      handleInput: () => undefined,
+      invalidate: () => undefined,
+      render: () => [],
+      renderContent: () => Array.from({ length: 24 }, (_, i) => ` row ${i + 1}`),
+    }));
     const custom = {
       id: "sf-test",
       name: "SF Test",
@@ -288,14 +296,7 @@ describe("extension detail helpers", () => {
       defaultEnabled: true,
       enabled: true,
       configurable: true,
-      getConfigPanel: async () =>
-        (() => ({
-          focused: false,
-          handleInput: () => undefined,
-          invalidate: () => undefined,
-          render: () => [],
-          renderContent: () => Array.from({ length: 24 }, (_, i) => ` row ${i + 1}`),
-        })) as never,
+      getConfigPanel: async () => configFactory as never,
     } as never;
     const overlay = new SfPiOverlayComponent(
       stubTheme,
@@ -307,7 +308,7 @@ describe("extension detail helpers", () => {
       "global",
       () => 12,
       () => undefined,
-      {} as never,
+      commandCtx,
       {} as never,
       () => [],
       () => undefined,
@@ -316,6 +317,7 @@ describe("extension detail helpers", () => {
 
     await Promise.resolve();
     const first = overlay.render(100).join("\n");
+    expect((configFactory.mock.calls[0] as unknown[] | undefined)?.[5]).toBe(commandCtx);
     expect(first).toContain("row 1");
     expect(first).toContain("PageUp/PageDown scroll");
     expect(first).not.toContain("row 20");


### PR DESCRIPTION
## What this PR does

Adds an opt-in, global/project-scoped SF LLM Gateway compaction-model preference while keeping Pi's active model as the shipped default.

## Why

Pi supports automatic and manual compaction but does not currently expose a separate summarization model. Users need a current-API replacement for legacy custom compaction hooks and a safe way to select an authenticated Gateway model without changing the chat model or bypassing the Gateway data boundary.

## How

- Add `sfPi.compaction.model` with `active` as the default and qualified `sf-llm-gateway/<model>` values for explicit selections.
- Intercept manual, threshold, and overflow compaction only when a dedicated model is configured; preserve usage and file context, bound request size, and fall back to Pi for unavailable, undersized, incomplete, or failed models.
- Add a dynamic Manager picker backed by the current authenticated Gateway catalog, with global/project inheritance and no reload required for preference-only changes.
- Pass the live command context to config-panel factories through an optional, backward-compatible Manager protocol argument.
- Show the effective compaction preference in Gateway status and document automatic/manual behavior and recovery.

## Checklist

- [x] I ran `npm run validate` locally, or I listed the focused checks I ran below
- [x] I updated the affected extension's `README.md`
- [x] I added or updated tests
- [x] I regenerated the catalog (`npm run generate-catalog`) after touching `manifest.json`
- [x] This PR is non-breaking

## Security and public-surface checklist

- [x] I considered whether this adds or changes a high-value durable mutation exposed through an LLM-callable tool; it does not
- [x] No high-value mutation is introduced
- [x] Execution intent flags are not treated as approval
- [x] No headless confirm-class operation is introduced
- [x] No operator auto-approve behavior is introduced
- [x] Dedicated summaries accept only authenticated `sf-llm-gateway/*` models and do not expose provider error details
- [x] Public docs, examples, tests, comments, and diagnostics use generic fixtures and contain no private identifiers or endpoints
- [x] The new setting and examples use public-safe names and placeholders

## Validation performed

- `npm exec vitest -- run extensions/sf-llm-gateway/tests extensions/sf-pi-manager/tests/extension-details.test.ts` — 42 files, 407 tests passed
- `npm run test:runtime-surface` — 30 tests passed
- `npm run validate:ci` — 561 files passed, 1 skipped; 4,011 tests passed, 39 skipped; catalog, docs, formatting, type, ESLint, architecture, lifecycle, and artifact checks passed
- `npm run lint` — passed

## Notes for reviewers

- `compaction.enabled` remains Pi's sole automatic-compaction switch; manual `/compact` remains available independently.
- The default `active` preference returns control to Pi without a model lookup or extra request.
- The dedicated model is request-local: this code never calls `pi.setModel()` or changes the active conversation model.
- No live provider calls, user settings changes, Salesforce org operations, or release actions were performed while authoring this PR.
