### PR TITLE
fix(gateway): reconcile inaccessible model state

### DIFF
--- a/catalog/index.json
+++ b/catalog/index.json
@@ -653,6 +653,7 @@
     "tools": [],
     "events": [
       "session_start",
+      "message_end",
       "session_before_compact",
       "turn_end",
       "model_select",
@@ -684,13 +685,15 @@
         "Pi alone persists/removes active credentials; setup and import paths write no secrets.",
         "Extension config stores only non-secret settings; credentials remain Pi-owned.",
         "Dedicated compaction accepts only authenticated sf-llm-gateway models, never changes the chat model, and falls back to Pi.",
+        "Sentinel-only empty access clears stale selectable models; ambiguous discovery failures retain the last-known catalog.",
+        "Recognized request failures are replaced with bounded guidance without echoing raw provider bodies.",
         "Pi's settings.json is mutated through pi-settings.ts helpers with race-aware reads."
       ]
     },
     "entry": "extensions/sf-llm-gateway/index.ts",
     "hasReadme": true,
     "hasTests": true,
-    "srcLoc": 9376
+    "srcLoc": 9589
   },
   {
     "id": "sf-lsp",

--- a/catalog/registry.ts
+++ b/catalog/registry.ts
@@ -205,7 +205,7 @@ export const SF_PI_REGISTRY: readonly SfPiExtension[] = [
     defaultEnabled: true,
     commands: ["/sf-llm-gateway"],
     providers: ["sf-llm-gateway"],
-    events: ["session_start","session_before_compact","turn_end","model_select","after_provider_response","session_shutdown"],
+    events: ["session_start","message_end","session_before_compact","turn_end","model_select","after_provider_response","session_shutdown"],
     configurable: true,
     getConfigPanel: async () => {
       const mod = await import("../extensions/sf-llm-gateway/lib/config-panel.ts");

--- a/docs/extensions/sf-llm-gateway.md
+++ b/docs/extensions/sf-llm-gateway.md
@@ -34,6 +34,8 @@ Open its Manager detail or change its package state with:
 - Pi alone persists/removes active credentials; setup and import paths write no secrets.
 - Extension config stores only non-secret settings; credentials remain Pi-owned.
 - Dedicated compaction accepts only authenticated sf-llm-gateway models, never changes the chat model, and falls back to Pi.
+- Sentinel-only empty access clears stale selectable models; ambiguous discovery failures retain the last-known catalog.
+- Recognized request failures are replaced with bounded guidance without echoing raw provider bodies.
 - Pi's settings.json is mutated through pi-settings.ts helpers with race-aware reads.
 
 ## Exact reference
@@ -49,7 +51,7 @@ Open its Manager detail or change its package state with:
 - **Commands:** `/sf-llm-gateway`
 - **LLM tools:** _none_
 - **Providers:** `sf-llm-gateway`
-- **Events/hooks:** `session_start`, `session_before_compact`, `turn_end`, `model_select`, `after_provider_response`, `session_shutdown`
+- **Events/hooks:** `session_start`, `message_end`, `session_before_compact`, `turn_end`, `model_select`, `after_provider_response`, `session_shutdown`
 
 </details>
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -105,6 +105,9 @@ Jump to an extension's Troubleshooting section to see the full fix. This index i
 
 - No models are available after installation
 - Login saved the credential but refresh failed
+- Refresh reports no assigned models
+- A request reports `team_model_access_denied`
+- A request says the provider is not configured
 - A discovered model shows conservative metadata
 - Requests fail while `curl` works on macOS
 - Usage or throttle status is stale

--- a/extensions/sf-llm-gateway/AGENTS.md
+++ b/extensions/sf-llm-gateway/AGENTS.md
@@ -23,6 +23,7 @@ Repo-level rules still apply; see root `AGENTS.md`.
 | Discovery metadata + family inference          | `lib/models.ts`                    |
 | Complete Provider + model discovery            | `lib/provider.ts`                  |
 | Provider auth + session context                | `lib/provider-auth.ts`             |
+| Protocol-neutral request diagnostics           | `lib/request-diagnostics.ts`       |
 | Dedicated compaction policy                    | `lib/compaction.ts`                |
 | Scoped compaction preference                   | `lib/compaction-settings.ts`       |
 | Manager compaction model picker                | `lib/compaction-model-picker.ts`   |
@@ -89,6 +90,10 @@ copy.
 8. **Dedicated compaction is opt-in and bounded.** `active` leaves Pi's compaction untouched.
    Explicit selections must come from the authenticated Gateway catalog, never change the chat
    model, preserve summary usage/file context, and fall back to Pi without exposing provider errors.
+9. **Access state beats stale availability.** A sentinel-only `no-default-models` discovery result
+   publishes an empty catalog so revoked models cannot remain selectable; mixed callable results
+   keep their peers, while ambiguous empty/network failures retain the last-known catalog. Normalize
+   recognized request failures through `message_end` without changing models, credentials, or settings.
 
 ## Command handler pattern
 

--- a/extensions/sf-llm-gateway/README.md
+++ b/extensions/sf-llm-gateway/README.md
@@ -14,7 +14,10 @@ bounded terminal error guidance.
 
 Startup performs no model-discovery request. Pi restores the last successful
 provider catalog; a fresh uncached installation exposes no models until login or
-an explicit refresh succeeds.
+an explicit refresh succeeds. Network failures and ambiguous empty discovery
+responses retain that catalog. A sentinel-only `no-default-models` result is an
+explicit access-empty state instead: SF Pi clears stale Gateway entries from the
+selector until a later refresh returns callable models.
 
 ## Connecting
 
@@ -131,6 +134,8 @@ response material; treat it as private diagnostic evidence and never commit it.
   policy, or secret ships in source.
 - Provider setup performs no hidden model selection, enable/disable, discovery,
   usage probe, or update beyond the explicitly chosen action.
+- Recognized access and configuration failures are replaced with bounded,
+  protocol-neutral guidance; raw provider response bodies are not repeated.
 - CA installation/download steps are explicit and human-confirmed.
 
 ## Troubleshooting
@@ -142,6 +147,21 @@ catalog.
 **Login saved the credential but refresh failed:** Run the doctor to distinguish
 wrong root, authentication, redirect, TLS, timeout, or service failure. A failed
 refresh does not replace the last successful cache.
+
+**Refresh reports no assigned models:** The Gateway returned the explicit
+`no-default-models` access state, so SF Pi removed stale Gateway models from the
+selector. Request model access, then rerun `/sf-llm-gateway refresh`. SF Pi does
+not silently switch the active conversation model or rewrite default settings.
+
+**A request reports `team_model_access_denied`:** Run
+`/sf-llm-gateway refresh`, then choose one of the returned models with `/model`.
+If refresh returns no models, request model access from your Gateway
+administrator.
+
+**A request says the provider is not configured:** Run
+`/sf-llm-gateway status`. Depending on the reported state, enable the provider,
+run setup for the endpoint, or authenticate with `/login sf-llm-gateway`; then
+refresh the catalog.
 
 **A discovered model shows conservative metadata:** Refresh the catalog. Exact
 public Pi catalog matches can contribute portable metadata, but provider

--- a/extensions/sf-llm-gateway/index.ts
+++ b/extensions/sf-llm-gateway/index.ts
@@ -11,6 +11,7 @@
  * - Registers with an empty static model list, then lets Pi restore the previous
  *   provider-scoped dynamic catalog without network.
  * - Authenticated model discovery via `/v1/models` supplies all callable model IDs
+ * - Sentinel-only empty access clears stale selectable models; ambiguous failures retain cache
  * - Gateway metadata plus generic family-aware inference defines discovered models
  * - Keeps `models.json` overrides above the registered Provider through Pi composition
  * - Shows an explicit SF LLM Gateway footer status when one of these models is active
@@ -56,7 +57,9 @@
  *   model_select                | model changes                       | Refresh footer without mutating thinking
  *   after_provider_response     | model is gateway model + 2xx       | Clear any live throttle/upstream warning
  *   after_provider_response     | model is gateway model + 429       | Record throttle signal, footer shows ⚠ badge for 60s
+ *   after_provider_response     | model is gateway model + 401/403   | Record access signal, footer shows ⚠ badge for 60s
  *   after_provider_response     | model is gateway model + 5xx       | Record upstream signal, footer shows ⚠ badge for 60s
+ *   message_end                 | recognized gateway request error    | Replace raw error with bounded recovery guidance
  *   session_before_compact      | dedicated model configured          | Summarize through that model or fall back to Pi
  *   session_shutdown            | —                                  | Cancel credential UI; clear cwd/auth/footer/provider state
  *   /command (no args)          | interactive UI                     | Open Manager detail page
@@ -73,6 +76,7 @@
  * - Start at the extension entry point to see the runtime spine
  * - Then read provider registration/discovery in lib/provider.ts
  * - Provider auth + session context live in lib/provider-auth.ts
+ * - Protocol-neutral request error guidance lives in lib/request-diagnostics.ts
  * - Dedicated-model compaction lives in lib/compaction.ts and lib/compaction-settings.ts
  * - Monthly usage caching lives in lib/monthly-usage.ts
  * - Pi settings mutations live in lib/pi-settings.ts
@@ -139,6 +143,7 @@ import {
 } from "./lib/pi-settings.ts";
 import { gatewayProviderRuntime } from "./lib/provider.ts";
 import { handleGatewayCompaction } from "./lib/compaction.ts";
+import { handleGatewayRequestDiagnostics } from "./lib/request-diagnostics.ts";
 import { buildGatewayCompactionModelOptions } from "./lib/compaction-settings.ts";
 import { fetchGatewayDoctorReport, formatGatewayDoctorReport } from "./lib/doctor.ts";
 import { countTokens, estimateSpend, formatTokenReport } from "./lib/token-counter.ts";
@@ -303,6 +308,7 @@ export default function sfLlmGatewayInternalExtension(pi: ExtensionAPI) {
   // model persistence, refresh coordination, and API dispatch from this point on.
   pi.registerProvider(gatewayProviderRuntime.provider);
 
+  pi.on("message_end", handleGatewayRequestDiagnostics);
   pi.on("session_before_compact", handleGatewayCompaction);
 
   // Contribute to the aggregated `/sf-pi doctor` view. The standalone
@@ -664,12 +670,15 @@ async function handleRefreshCommand(pi: ExtensionAPI, ctx: ExtensionCommandConte
     { ...getRuntimeStatusState(), discovery: state },
     { effectiveBaseUrl: runtimeAuth?.baseUrl },
   );
+  const accessEmpty = state.accessState === "no-default-models";
   await emitCommandOutput(
     pi,
     ctx,
-    `SF LLM Gateway refreshed (${state.modelIds.length} models, source: ${state.source}).`,
+    accessEmpty
+      ? "SF LLM Gateway refresh completed with no assigned models."
+      : `SF LLM Gateway refreshed (${state.modelIds.length} models, source: ${state.source}).`,
     report,
-    state.error ? "warning" : "info",
+    state.error || accessEmpty ? "warning" : "info",
   );
 }
 
@@ -685,7 +694,12 @@ async function handleModelsCommand(pi: ExtensionAPI, ctx: ExtensionCommandContex
           const inferred = inferModelDefinition(id);
           return `- ${id}  ::  family=${getModelFamily(id)}  ::  ${inferred.name}`;
         })
-      : ["- none (authenticate and refresh to discover models)"]),
+      : state.accessState === "no-default-models"
+        ? [
+            "- none — the Gateway reported no default models for this credential",
+            `- request access, then run /${FRIENDLY_COMMAND_NAME} refresh`,
+          ]
+        : ["- none (authenticate and refresh to discover models)"]),
   ];
   await emitCommandOutput(pi, ctx, "SF LLM Gateway models.", lines.join("\n"), "info");
 }
@@ -1428,7 +1442,7 @@ async function applyGatewayDefault(
 ): Promise<string[]> {
   const settingsPath = scope === "project" ? projectSettingsPath(ctx.cwd) : globalSettingsPath();
 
-  await refreshGatewayProvider(ctx);
+  const state = await refreshGatewayProvider(ctx);
 
   const configuredDefault = getEffectiveDefaultModelSetting(ctx.cwd);
   const resolvedDefault = resolveGatewayDefaultModel(ctx, [
@@ -1436,11 +1450,17 @@ async function applyGatewayDefault(
     isGatewayProvider(configuredDefault.provider) ? configuredDefault.modelId : undefined,
   ]);
   if (!resolvedDefault) {
-    return [
-      `Default unchanged in ${scope} settings.`,
-      "- No callable gateway models were discovered.",
-      `- Authenticate with /login ${PROVIDER_NAME}, then refresh and try again.`,
-    ];
+    return state.accessState === "no-default-models"
+      ? [
+          `Default unchanged in ${scope} settings.`,
+          "- The Gateway reported no default models for this credential.",
+          `- Request model access, then run /${FRIENDLY_COMMAND_NAME} refresh and try again.`,
+        ]
+      : [
+          `Default unchanged in ${scope} settings.`,
+          "- No callable gateway models were discovered.",
+          `- Authenticate with /login ${PROVIDER_NAME}, then refresh and try again.`,
+        ];
   }
   const effectiveModelId = resolvedDefault.modelId;
   const effectiveModel = inferModelDefinition(effectiveModelId);
@@ -1802,11 +1822,16 @@ async function enableGatewayOperation(
     existingGatewayDefault,
   ]);
   if (!resolvedDefault) {
+    const accessEmpty = state.accessState === "no-default-models";
     return {
-      summary: "SF LLM Gateway has no discovered models.",
+      summary: accessEmpty
+        ? "SF LLM Gateway has no assigned models."
+        : "SF LLM Gateway has no discovered models.",
       details: [
         `Discovery source: ${state.source}${state.error ? ` (${state.error})` : ""}`,
-        `Authenticate with /login ${PROVIDER_NAME}, then refresh and try again.`,
+        accessEmpty
+          ? `Request model access, then run /${FRIENDLY_COMMAND_NAME} refresh and try again.`
+          : `Authenticate with /login ${PROVIDER_NAME}, then refresh and try again.`,
       ].join("\n"),
       level: "warning",
     };

--- a/extensions/sf-llm-gateway/lib/doctor.ts
+++ b/extensions/sf-llm-gateway/lib/doctor.ts
@@ -10,7 +10,9 @@ import {
 } from "./config.ts";
 import { toGatewayOpenAiBaseUrl, toGatewayRootBaseUrl } from "./gateway-url.ts";
 import { fetchWithTimeout } from "./models.ts";
+import { isNoDefaultModelsOnlyDiscoveryPayload } from "./models-internal/discovery-sentinels.ts";
 import { gatewayProviderRuntime } from "./provider.ts";
+import { isGatewayModelAccessDeniedError } from "./request-diagnostics.ts";
 import { type GatewayCaProbeFailureClass, writeCaProbeState } from "./ca-probe-state.ts";
 import {
   collectUsableCaBundlePaths,
@@ -101,6 +103,9 @@ export function classifyHttpResult(
   status: number,
   bodyPreview: string,
 ): GatewayCaProbeFailureClass {
+  if (status >= 200 && status < 300 && isNoDefaultModelsOnlyDiscoveryPayload(bodyPreview)) {
+    return "other";
+  }
   if (status >= 200 && status < 300) return null;
   if (status === 401) return "auth";
   if (
@@ -131,6 +136,12 @@ export function aggregateFailureClass(
 }
 
 export function interpretGatewayHttpResult(status: number, bodyPreview: string): string {
+  if (status >= 200 && status < 300 && isNoDefaultModelsOnlyDiscoveryPayload(bodyPreview)) {
+    return `Authenticated, but the Gateway reported no default models for this credential. Request model access, then run /${FRIENDLY_COMMAND_NAME} refresh.`;
+  }
+  if (isGatewayModelAccessDeniedError(bodyPreview)) {
+    return `Gateway model access was denied. Run /${FRIENDLY_COMMAND_NAME} refresh; if no models are returned, request model access from your Gateway administrator.`;
+  }
   if (status >= 200 && status < 300) {
     if (/server_root_path|proxy_base_url/.test(bodyPreview)) {
       return "OK (LiteLLM proxy signature)";
@@ -355,15 +366,17 @@ async function runGatewayCheck(
       },
       DOCTOR_TIMEOUT_MS,
     );
-    const bodyPreview = (await response.text()).slice(0, BODY_PREVIEW_LIMIT);
+    const body = await response.text();
+    const bodyPreview = body.slice(0, BODY_PREVIEW_LIMIT);
+    const failureClass = classifyHttpResult(response.status, body);
     return {
       name,
       url,
       status: response.status,
-      ok: response.ok,
-      interpretation: interpretGatewayHttpResult(response.status, bodyPreview),
+      ok: response.ok && failureClass === null,
+      interpretation: interpretGatewayHttpResult(response.status, body),
       bodyPreview: bodyPreview || undefined,
-      failureClass: response.ok ? null : classifyHttpResult(response.status, bodyPreview),
+      failureClass,
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/extensions/sf-llm-gateway/lib/models-internal/discovery-sentinels.ts
+++ b/extensions/sf-llm-gateway/lib/models-internal/discovery-sentinels.ts
@@ -3,14 +3,46 @@
  * Non-callable model IDs that can appear in LiteLLM discovery responses.
  *
  * These values describe access/listing state, not models that Pi can call.
- * Keep them out of the registered provider catalog and discovery cache so a
- * transient proxy-side listing regression cannot replace the last successful
- * catalog with a dead selector entry.
+ * Keep them out of the registered provider catalog and discovery cache. A
+ * sentinel-only result is handled separately as an authoritative empty-access
+ * state; mixed results retain their callable peers.
  */
-const NON_CALLABLE_DISCOVERY_MODEL_IDS = new Set(["no-default-models"]);
+export const NO_DEFAULT_MODELS_SENTINEL = "no-default-models";
+
+const NON_CALLABLE_DISCOVERY_MODEL_IDS = new Set([NO_DEFAULT_MODELS_SENTINEL]);
 
 export function isCallableDiscoveredModelId(id: string): boolean {
   return !NON_CALLABLE_DISCOVERY_MODEL_IDS.has(id);
+}
+
+/**
+ * Sentinel-only discovery is an explicit access-empty result, not a transport
+ * failure. Publishing an empty catalog prevents last-known models that may no
+ * longer be authorized from remaining selectable. An ordinary empty response
+ * without this sentinel stays ambiguous and must retain the previous catalog.
+ */
+export function isNoDefaultModelsAccessState(
+  callableIds: readonly string[],
+  filteredIds: readonly string[],
+): boolean {
+  return callableIds.length === 0 && filteredIds.includes(NO_DEFAULT_MODELS_SENTINEL);
+}
+
+/** Parse a model-discovery response without treating mixed sentinel/peer results as access-empty. */
+export function isNoDefaultModelsOnlyDiscoveryPayload(body: string): boolean {
+  try {
+    const parsed = JSON.parse(body) as { data?: Array<{ id?: unknown }> };
+    if (!Array.isArray(parsed.data)) return false;
+    const ids = parsed.data
+      .map((entry) => (typeof entry?.id === "string" ? entry.id.trim() : ""))
+      .filter(Boolean);
+    return (
+      ids.includes(NO_DEFAULT_MODELS_SENTINEL) &&
+      ids.filter(isCallableDiscoveredModelId).length === 0
+    );
+  } catch {
+    return false;
+  }
 }
 
 export function hasNonCallableDiscoveredModelIds(ids: readonly string[]): boolean {

--- a/extensions/sf-llm-gateway/lib/provider-telemetry.ts
+++ b/extensions/sf-llm-gateway/lib/provider-telemetry.ts
@@ -9,14 +9,14 @@
  * Rules:
  * - Pure functions + a single in-memory slot; no I/O.
  * - Healthy (2xx) responses clear any active warning immediately.
- * - Warnings (>=429) expire after `SIGNAL_TTL_MS` so stale badges don't linger.
+ * - Access, throttle, and upstream warnings expire after `SIGNAL_TTL_MS` so stale badges don't linger.
  * - Header availability is best-effort per Pi docs; all parsers are null-safe
  *   and degrade gracefully when a header is missing.
  */
 
 export const SIGNAL_TTL_MS = 60_000;
 
-export type ProviderSignalKind = "healthy" | "throttled" | "upstream";
+export type ProviderSignalKind = "healthy" | "access" | "throttled" | "upstream";
 
 /** Snapshot of the last provider response relevant to the gateway footer. */
 export interface ProviderSignal {
@@ -64,7 +64,8 @@ export function recordProviderResponse(
   }
 
   const normalizedHeaders = normalizeHeaders(headers);
-  const kind: ProviderSignalKind = status === 429 ? "throttled" : "upstream";
+  const kind: ProviderSignalKind =
+    status === 401 || status === 403 ? "access" : status === 429 ? "throttled" : "upstream";
   const retryAfterSec = parseRetryAfter(normalizedHeaders["retry-after"], now);
   const remainingRequests = parseInteger(normalizedHeaders["x-ratelimit-remaining-requests"]);
   const remainingTokens = parseInteger(normalizedHeaders["x-ratelimit-remaining-tokens"]);
@@ -117,6 +118,10 @@ export function formatProviderSignalBadge(signal: ProviderSignal | null): string
     const retryPart =
       typeof signal.retryAfterSec === "number" ? ` · retry ${signal.retryAfterSec}s` : "";
     return `⚠ ${signal.status}${retryPart}`;
+  }
+
+  if (signal.kind === "access") {
+    return `⚠ access ${signal.status}`;
   }
 
   if (signal.kind === "upstream") {

--- a/extensions/sf-llm-gateway/lib/provider.ts
+++ b/extensions/sf-llm-gateway/lib/provider.ts
@@ -22,7 +22,10 @@ import {
   type GatewayModelInfoMap,
   type TaggedGatewayModel,
 } from "./models.ts";
-import { filterCallableDiscoveredModelIds } from "./models-internal/discovery-sentinels.ts";
+import {
+  filterCallableDiscoveredModelIds,
+  isNoDefaultModelsAccessState,
+} from "./models-internal/discovery-sentinels.ts";
 import {
   GatewayModelDiscoveryError,
   type GatewayModelIdDiscovery,
@@ -51,6 +54,8 @@ export interface GatewayNativeDiscoveryState {
   discoveredAt?: string;
   error?: string;
   filteredModelIds?: string[];
+  /** Gateway-confirmed empty access; stale cached models were intentionally cleared. */
+  accessState?: "no-default-models";
 }
 
 export interface GatewayFetchers {
@@ -223,6 +228,19 @@ export function createGatewayProviderRuntime(
           ...modelIdDiscovery.ids.filter((id) => !callableIds.includes(id)),
         ]),
       ];
+      if (isNoDefaultModelsAccessState(callableIds, filteredIds)) {
+        lastDiscovery = {
+          modelIds: [],
+          source: "gateway",
+          discoveredAt: now().toISOString(),
+          filteredModelIds: filteredIds,
+          accessState: "no-default-models",
+        };
+        // createProvider publishes this successful empty result to both its
+        // in-memory catalog and Pi's provider-scoped ModelsStore. Network,
+        // protocol, and ambiguous empty failures still throw and retain cache.
+        return [];
+      }
       if (callableIds.length === 0) {
         throw new Error("Gateway returned zero callable models.");
       }

--- a/extensions/sf-llm-gateway/lib/request-diagnostics.ts
+++ b/extensions/sf-llm-gateway/lib/request-diagnostics.ts
@@ -1,0 +1,130 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/** Protocol-neutral, public-safe diagnostics for finalized Gateway request errors. */
+import type { ExtensionContext, MessageEndEvent } from "@earendil-works/pi-coding-agent";
+import { getGatewayConfig, PROVIDER_NAME } from "./config.ts";
+import { gatewayProviderRuntime } from "./provider.ts";
+
+export const MODEL_ACCESS_DENIED_CODE = "team_model_access_denied";
+const MODEL_ACCESS_DENIED_PREFIX = "SF LLM Gateway denied access to ";
+const GENERIC_UNCONFIGURED_ERROR = `Provider is not configured: ${PROVIDER_NAME}`;
+
+export interface GatewayRequestReadiness {
+  enabled: boolean;
+  baseUrlConfigured: boolean;
+  credentialConfigured: boolean;
+  modelId?: string;
+}
+
+export interface GatewayRequestDiagnosticsDependencies {
+  getConfig?: (cwd: string) => { enabled: boolean; baseUrl?: string };
+  hasConfiguredCredential?: () => Promise<boolean>;
+}
+
+export function isGatewayModelAccessDeniedError(errorMessage: string): boolean {
+  return errorMessage.includes(MODEL_ACCESS_DENIED_CODE);
+}
+
+export function normalizeGatewayRequestError(
+  errorMessage: string,
+  readiness: GatewayRequestReadiness,
+): string | undefined {
+  if (errorMessage.startsWith(MODEL_ACCESS_DENIED_PREFIX)) return undefined;
+
+  if (isGatewayModelAccessDeniedError(errorMessage)) {
+    const modelId = readiness.modelId?.trim();
+    const model =
+      modelId && /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$/u.test(modelId)
+        ? `${PROVIDER_NAME}/${modelId}`
+        : "the selected Gateway model";
+    return [
+      `${MODEL_ACCESS_DENIED_PREFIX}${model} (${MODEL_ACCESS_DENIED_CODE}).`,
+      `Run /${PROVIDER_NAME} refresh, then choose an available model with /model.`,
+      "If refresh returns no models, request model access from your Gateway administrator.",
+    ].join("\n");
+  }
+
+  if (!errorMessage.includes(GENERIC_UNCONFIGURED_ERROR)) return undefined;
+
+  if (!readiness.enabled) {
+    return [
+      "SF LLM Gateway is disabled for requests.",
+      `Run /${PROVIDER_NAME} on to enable it, then retry.`,
+    ].join("\n");
+  }
+  if (!readiness.baseUrlConfigured && !readiness.credentialConfigured) {
+    return [
+      "SF LLM Gateway has no usable endpoint or credential.",
+      `Run /${PROVIDER_NAME} setup, then /login ${PROVIDER_NAME} and /${PROVIDER_NAME} refresh.`,
+    ].join("\n");
+  }
+  if (!readiness.baseUrlConfigured) {
+    return [
+      "SF LLM Gateway has no usable endpoint.",
+      `Run /${PROVIDER_NAME} setup, then retry.`,
+    ].join("\n");
+  }
+  if (!readiness.credentialConfigured) {
+    return [
+      "SF LLM Gateway has no usable credential.",
+      `Run /login ${PROVIDER_NAME}, then /${PROVIDER_NAME} refresh.`,
+    ].join("\n");
+  }
+  return [
+    "SF LLM Gateway authentication could not be resolved for this request.",
+    `Run /${PROVIDER_NAME} doctor. If the key is rejected, run /login ${PROVIDER_NAME}, then refresh.`,
+  ].join("\n");
+}
+
+export async function handleGatewayRequestDiagnostics(
+  event: MessageEndEvent,
+  ctx: ExtensionContext,
+  dependencies: GatewayRequestDiagnosticsDependencies = {},
+): Promise<{ message: MessageEndEvent["message"] } | undefined> {
+  const message = event.message;
+  if (message.role !== "assistant" || message.stopReason !== "error") return undefined;
+  if (message.provider !== PROVIDER_NAME || !message.errorMessage) return undefined;
+
+  const rawError = message.errorMessage;
+  const isModelAccessDenied = isGatewayModelAccessDeniedError(rawError);
+  const isGenericUnconfigured = rawError.includes(GENERIC_UNCONFIGURED_ERROR);
+  if (
+    rawError.startsWith(MODEL_ACCESS_DENIED_PREFIX) ||
+    (!isModelAccessDenied && !isGenericUnconfigured)
+  ) {
+    return undefined;
+  }
+
+  let enabled = true;
+  let baseUrlConfigured = true;
+  let credentialConfigured = true;
+  if (isGenericUnconfigured) {
+    const config = (dependencies.getConfig ?? getGatewayConfig)(ctx.cwd);
+    enabled = config.enabled;
+    baseUrlConfigured = Boolean(config.baseUrl);
+    try {
+      credentialConfigured = await (
+        dependencies.hasConfiguredCredential ??
+        (() => gatewayProviderRuntime.authController.hasConfiguredCredential())
+      )();
+    } catch {
+      // If readiness inspection itself fails, avoid falsely claiming the key is absent.
+      // The generic doctor guidance remains accurate and public-safe.
+      credentialConfigured = true;
+    }
+  }
+
+  const normalized = normalizeGatewayRequestError(rawError, {
+    enabled,
+    baseUrlConfigured,
+    credentialConfigured,
+    modelId: message.model,
+  });
+  if (!normalized || normalized === rawError) return undefined;
+
+  return {
+    message: {
+      ...message,
+      errorMessage: normalized,
+    },
+  };
+}

--- a/extensions/sf-llm-gateway/lib/status.ts
+++ b/extensions/sf-llm-gateway/lib/status.ts
@@ -121,6 +121,13 @@ export function buildStatusReport(
     `Keys on account: ${formatKeyListReportLine(state.keyList, state.keyListError, state.keyInfo?.keyName)}`,
     ...formatApiKeyGuidanceReportLines(ctx.cwd, state),
     "",
+    ...(discovery?.accessState === "no-default-models"
+      ? [
+          "Model access: no default models assigned",
+          "Catalog action: stale Gateway models removed from the selector",
+          `Recovery: request access, then run /${PROVIDER_NAME} refresh`,
+        ]
+      : []),
     `Model discovery: ${discovery?.source ?? "not run"}${discovery?.error ? ` ⚠ ${discovery.error}` : ""}`,
     `Discovered models: ${discovery?.modelIds.length ?? 0}`,
     ...(discovery?.error

--- a/extensions/sf-llm-gateway/manifest.json
+++ b/extensions/sf-llm-gateway/manifest.json
@@ -10,6 +10,7 @@
   "providers": ["sf-llm-gateway"],
   "events": [
     "session_start",
+    "message_end",
     "session_before_compact",
     "turn_end",
     "model_select",
@@ -41,6 +42,8 @@
       "Pi alone persists/removes active credentials; setup and import paths write no secrets.",
       "Extension config stores only non-secret settings; credentials remain Pi-owned.",
       "Dedicated compaction accepts only authenticated sf-llm-gateway models, never changes the chat model, and falls back to Pi.",
+      "Sentinel-only empty access clears stale selectable models; ambiguous discovery failures retain the last-known catalog.",
+      "Recognized request failures are replaced with bounded guidance without echoing raw provider bodies.",
       "Pi's settings.json is mutated through pi-settings.ts helpers with race-aware reads."
     ]
   }

--- a/extensions/sf-llm-gateway/tests/doctor.test.ts
+++ b/extensions/sf-llm-gateway/tests/doctor.test.ts
@@ -35,7 +35,32 @@ describe("interpretGatewayHttpResult", () => {
     );
   });
 
-  it("treats 2xx as ok", () => {
+  it("reports sentinel-only discovery as an access warning despite HTTP success", () => {
+    expect(interpretGatewayHttpResult(200, '{"data":[{"id":"no-default-models"}]}')).toContain(
+      "no default models",
+    );
+  });
+
+  it("does not treat a sentinel alongside callable peers as access-empty", () => {
+    expect(
+      interpretGatewayHttpResult(
+        200,
+        '{"data":[{"id":"no-default-models"},{"id":"callable-peer"}]}',
+      ),
+    ).toBe("OK");
+  });
+
+  it("normalizes explicit model-access denial into refresh and access guidance", () => {
+    const text = interpretGatewayHttpResult(
+      403,
+      '{"error":{"code":"team_model_access_denied","message":"denied"}}',
+    );
+    expect(text).toContain("/sf-llm-gateway refresh");
+    expect(text).toContain("request model access");
+    expect(text).not.toContain('{"error"');
+  });
+
+  it("treats ordinary 2xx as ok", () => {
     expect(interpretGatewayHttpResult(200, "{}")).toBe("OK");
   });
 });
@@ -111,7 +136,14 @@ describe("classifyHttpResult", () => {
     expect(classifyHttpResult(405, "")).toBe("other");
   });
 
-  it("maps 2xx to null", () => {
+  it("maps sentinel-only 2xx to warning while allowing mixed callable peers", () => {
+    expect(classifyHttpResult(200, '{"data":[{"id":"no-default-models"}]}')).toBe("other");
+    expect(
+      classifyHttpResult(200, '{"data":[{"id":"no-default-models"},{"id":"callable-peer"}]}'),
+    ).toBe(null);
+  });
+
+  it("maps ordinary 2xx to null", () => {
     expect(classifyHttpResult(200, "{}")).toBe(null);
     expect(classifyHttpResult(204, "")).toBe(null);
   });

--- a/extensions/sf-llm-gateway/tests/lifecycle.test.ts
+++ b/extensions/sf-llm-gateway/tests/lifecycle.test.ts
@@ -156,13 +156,14 @@ describe("gateway extension lifecycle", () => {
     vi.restoreAllMocks();
   });
 
-  it("registers the dedicated-model compaction policy hook", async () => {
+  it("registers compaction and protocol-neutral request-diagnostic hooks", async () => {
     const { default: extension } = await import("../index.ts");
     const pi = makeFakePi();
 
     extension(pi as never);
 
     expect(pi.handlers.session_before_compact).toHaveLength(1);
+    expect(pi.handlers.message_end).toHaveLength(1);
   });
 
   it("registers one complete native Provider", async () => {

--- a/extensions/sf-llm-gateway/tests/provider-telemetry.test.ts
+++ b/extensions/sf-llm-gateway/tests/provider-telemetry.test.ts
@@ -151,6 +151,11 @@ describe("recordProviderResponse", () => {
     expect(signal!.modelId).toBe("example-native-message-model");
   });
 
+  it("classifies 401 and 403 as access warnings", () => {
+    expect(recordProviderResponse(401, {}, "example-model")?.kind).toBe("access");
+    expect(recordProviderResponse(403, {}, "example-model")?.kind).toBe("access");
+  });
+
   it("classifies 5xx as upstream even without retry-after", () => {
     const signal = recordProviderResponse(503, { "content-type": "application/json" }, undefined);
     expect(signal!.kind).toBe("upstream");
@@ -204,6 +209,16 @@ describe("formatProviderSignalBadge", () => {
         at: Date.now(),
       }),
     ).toBe("⚠ 429");
+  });
+
+  it("formats access signals", () => {
+    expect(
+      formatProviderSignalBadge({
+        kind: "access",
+        status: 403,
+        at: Date.now(),
+      }),
+    ).toBe("⚠ access 403");
   });
 
   it("formats upstream signals", () => {

--- a/extensions/sf-llm-gateway/tests/provider.test.ts
+++ b/extensions/sf-llm-gateway/tests/provider.test.ts
@@ -488,8 +488,78 @@ describe("complete native Gateway Provider", () => {
     expect(runtime.getLastDiscovery().filteredModelIds).toEqual(["no-default-models"]);
   });
 
-  it("rejects missing refresh inputs and leaves a fresh catalog empty when discovery has no callable models", async () => {
-    const zero = fetchers({ ids: [], filteredIds: ["no-default-models"] });
+  it("publishes sentinel-only access as an empty catalog and later restores granted models", async () => {
+    const network = fetchers({ ids: [], filteredIds: ["no-default-models"] });
+    const runtime = createGatewayProviderRuntime({
+      authController: authController(),
+      fetchers: network,
+      now: () => new Date("2026-07-23T04:05:06.000Z"),
+    });
+    const { models, modelsStore } = await configuredModels(runtime);
+    await modelsStore.write(PROVIDER_NAME, {
+      models: [cachedModel("stale-forbidden-model")],
+      checkedAt: 1,
+    });
+    await models.refresh({ allowNetwork: false });
+    expect(models.getModel(PROVIDER_NAME, "stale-forbidden-model")).toBeDefined();
+
+    const denied = await models.refresh({ allowNetwork: true });
+
+    expect(denied.errors.size).toBe(0);
+    expect(models.getModels(PROVIDER_NAME)).toEqual([]);
+    expect((await modelsStore.read(PROVIDER_NAME))?.models).toEqual([]);
+    expect(runtime.getLastDiscovery()).toEqual({
+      source: "gateway",
+      modelIds: [],
+      accessState: "no-default-models",
+      discoveredAt: "2026-07-23T04:05:06.000Z",
+      filteredModelIds: ["no-default-models"],
+    });
+
+    vi.mocked(network.modelIds).mockRejectedValueOnce(new Error("temporary discovery failure"));
+    const failed = await models.refresh({ allowNetwork: true });
+    expect(failed.errors.get(PROVIDER_NAME)?.message).toContain("Gateway model refresh failed");
+    expect(models.getModels(PROVIDER_NAME)).toEqual([]);
+    expect((await modelsStore.read(PROVIDER_NAME))?.models).toEqual([]);
+
+    vi.mocked(network.modelIds).mockResolvedValueOnce({ ids: ["restored-model"], filteredIds: [] });
+    vi.mocked(network.modelInfo).mockResolvedValueOnce({});
+    const restored = await models.refresh({ allowNetwork: true });
+
+    expect(restored.errors.size).toBe(0);
+    expect(models.getModel(PROVIDER_NAME, "restored-model")).toBeDefined();
+    expect(runtime.getLastDiscovery()).not.toHaveProperty("accessState");
+    expect((await modelsStore.read(PROVIDER_NAME))?.models.map((model) => model.id)).toEqual([
+      "restored-model",
+    ]);
+  });
+
+  it("retains a cached catalog for an ambiguous empty discovery without the access sentinel", async () => {
+    const network = fetchers({ ids: [], filteredIds: [] });
+    const runtime = createGatewayProviderRuntime({
+      authController: authController(),
+      fetchers: network,
+    });
+    const { models, modelsStore } = await configuredModels(runtime);
+    await modelsStore.write(PROVIDER_NAME, {
+      models: [cachedModel("last-known")],
+      checkedAt: 1,
+    });
+    await models.refresh({ allowNetwork: false });
+
+    const result = await models.refresh({ allowNetwork: true });
+
+    expect(result.errors.get(PROVIDER_NAME)?.message).toBe(
+      "Gateway returned zero callable models.",
+    );
+    expect(models.getModel(PROVIDER_NAME, "last-known")).toBeDefined();
+    expect((await modelsStore.read(PROVIDER_NAME))?.models.map((model) => model.id)).toEqual([
+      "last-known",
+    ]);
+  });
+
+  it("rejects missing refresh inputs and an ambiguous fresh empty catalog", async () => {
+    const zero = fetchers({ ids: [], filteredIds: [] });
     const runtime = createGatewayProviderRuntime({
       authController: authController(),
       fetchers: zero,

--- a/extensions/sf-llm-gateway/tests/request-diagnostics.test.ts
+++ b/extensions/sf-llm-gateway/tests/request-diagnostics.test.ts
@@ -1,0 +1,178 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/** Behavior proofs for protocol-neutral Gateway request diagnostics. */
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import type { ExtensionContext, MessageEndEvent } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it, vi } from "vitest";
+import {
+  handleGatewayRequestDiagnostics,
+  normalizeGatewayRequestError,
+  type GatewayRequestReadiness,
+} from "../lib/request-diagnostics.ts";
+
+const READY: GatewayRequestReadiness = {
+  enabled: true,
+  baseUrlConfigured: true,
+  credentialConfigured: true,
+  modelId: "example-model",
+};
+
+function errorMessage(
+  provider = "sf-llm-gateway",
+  message = "Provider is not configured: sf-llm-gateway",
+): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [],
+    api: "openai-completions",
+    provider,
+    model: "example-model",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "error",
+    errorMessage: message,
+    timestamp: Date.now(),
+  };
+}
+
+describe("normalizeGatewayRequestError", () => {
+  it.each([
+    'Error code: 403 - {"error":{"code":"team_model_access_denied","message":"denied"}}',
+    "Messages permission_error: team_model_access_denied",
+    "Gateway request failed (403): code=team_model_access_denied",
+  ])("normalizes model-access denial without leaking the provider body: %s", (raw) => {
+    const normalized = normalizeGatewayRequestError(raw, READY);
+
+    expect(normalized).toBe(
+      [
+        "SF LLM Gateway denied access to sf-llm-gateway/example-model (team_model_access_denied).",
+        "Run /sf-llm-gateway refresh, then choose an available model with /model.",
+        "If refresh returns no models, request model access from your Gateway administrator.",
+      ].join("\n"),
+    );
+    expect(normalized).not.toContain('{"error"');
+    expect(normalized).not.toContain("Tip: Agent retries");
+  });
+
+  it("does not echo an unsafe model identifier into access guidance", () => {
+    const normalized = normalizeGatewayRequestError("team_model_access_denied", {
+      ...READY,
+      modelId: "model\nprivate-detail",
+    });
+
+    expect(normalized).toContain("the selected Gateway model");
+    expect(normalized).not.toContain("private-detail");
+  });
+
+  it("is idempotent for an already normalized model-access error", () => {
+    const normalized = normalizeGatewayRequestError(
+      "SF LLM Gateway denied access to sf-llm-gateway/example-model (team_model_access_denied).\nRun /sf-llm-gateway refresh, then choose an available model with /model.",
+      READY,
+    );
+
+    expect(normalized).toBeUndefined();
+  });
+
+  it.each([
+    {
+      readiness: { ...READY, enabled: false },
+      expected:
+        "SF LLM Gateway is disabled for requests.\nRun /sf-llm-gateway on to enable it, then retry.",
+    },
+    {
+      readiness: { ...READY, baseUrlConfigured: false, credentialConfigured: false },
+      expected:
+        "SF LLM Gateway has no usable endpoint or credential.\nRun /sf-llm-gateway setup, then /login sf-llm-gateway and /sf-llm-gateway refresh.",
+    },
+    {
+      readiness: { ...READY, baseUrlConfigured: false },
+      expected: "SF LLM Gateway has no usable endpoint.\nRun /sf-llm-gateway setup, then retry.",
+    },
+    {
+      readiness: { ...READY, credentialConfigured: false },
+      expected:
+        "SF LLM Gateway has no usable credential.\nRun /login sf-llm-gateway, then /sf-llm-gateway refresh.",
+    },
+    {
+      readiness: READY,
+      expected:
+        "SF LLM Gateway authentication could not be resolved for this request.\nRun /sf-llm-gateway doctor. If the key is rejected, run /login sf-llm-gateway, then refresh.",
+    },
+  ])("turns Pi's generic auth error into targeted recovery guidance", ({ readiness, expected }) => {
+    expect(
+      normalizeGatewayRequestError("Provider is not configured: sf-llm-gateway", readiness),
+    ).toBe(expected);
+  });
+
+  it("does not rewrite unrelated request failures", () => {
+    expect(normalizeGatewayRequestError("Gateway request failed (403): policy denied", READY)).toBe(
+      undefined,
+    );
+    expect(
+      normalizeGatewayRequestError("Provider is not configured: another-provider", READY),
+    ).toBe(undefined);
+  });
+});
+
+describe("handleGatewayRequestDiagnostics", () => {
+  it("replaces a finalized Gateway assistant error through the message_end seam", async () => {
+    const message = errorMessage();
+    const event: MessageEndEvent = { type: "message_end", message };
+    const ctx = {
+      cwd: "/workspace",
+    } as ExtensionContext;
+
+    const result = await handleGatewayRequestDiagnostics(event, ctx, {
+      getConfig: () => ({ enabled: true, baseUrl: "https://gateway.example.test" }),
+      hasConfiguredCredential: vi.fn(async () => false),
+    });
+
+    expect(result?.message).toMatchObject({
+      role: "assistant",
+      provider: "sf-llm-gateway",
+      stopReason: "error",
+      errorMessage:
+        "SF LLM Gateway has no usable credential.\nRun /login sf-llm-gateway, then /sf-llm-gateway refresh.",
+    });
+    expect(message.errorMessage).toBe("Provider is not configured: sf-llm-gateway");
+  });
+
+  it("leaves successful, non-Gateway, and unrecognized errors unchanged", async () => {
+    const deps = {
+      getConfig: () => ({ enabled: true, baseUrl: "https://gateway.example.test" }),
+      hasConfiguredCredential: vi.fn(async () => true),
+    };
+    const successful = { ...errorMessage(), stopReason: "stop" as const, errorMessage: undefined };
+
+    await expect(
+      handleGatewayRequestDiagnostics(
+        { type: "message_end", message: successful },
+        { cwd: "/workspace" } as ExtensionContext,
+        deps,
+      ),
+    ).resolves.toBeUndefined();
+    await expect(
+      handleGatewayRequestDiagnostics(
+        { type: "message_end", message: errorMessage("another-provider") },
+        { cwd: "/workspace" } as ExtensionContext,
+        deps,
+      ),
+    ).resolves.toBeUndefined();
+    await expect(
+      handleGatewayRequestDiagnostics(
+        {
+          type: "message_end",
+          message: errorMessage("sf-llm-gateway", "Gateway request failed (403): policy denied"),
+        },
+        { cwd: "/workspace" } as ExtensionContext,
+        deps,
+      ),
+    ).resolves.toBeUndefined();
+    expect(deps.hasConfiguredCredential).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/sf-llm-gateway/tests/status.test.ts
+++ b/extensions/sf-llm-gateway/tests/status.test.ts
@@ -220,6 +220,37 @@ describe("buildStatusReport", () => {
     expect(report).toContain("Discovered models: 2");
   });
 
+  it("shows an authoritative no-default-models access state without cache-fallback wording", () => {
+    process.env.HOME = makeTempDir("gateway-home-");
+    const ctx = {
+      cwd: makeTempDir("gateway-status-no-default-models-"),
+      model: { provider: "sf-llm-gateway", id: "stale-model" },
+      modelRegistry: {
+        getProviderAuthStatus: () => ({ configured: true, source: "stored" }),
+      },
+      getContextUsage: () => null,
+    } as unknown as ExtensionContext;
+
+    const report = buildStatusReport(
+      ctx,
+      true,
+      withDefaults({
+        discovery: {
+          source: "gateway",
+          modelIds: [],
+          accessState: "no-default-models",
+          filteredModelIds: ["no-default-models"],
+          discoveredAt: "2026-07-23T04:05:06.000Z",
+        },
+      }),
+    );
+
+    expect(report).toContain("Model access: no default models assigned");
+    expect(report).toContain("Catalog action: stale Gateway models removed from the selector");
+    expect(report).toContain("Recovery: request access, then run /sf-llm-gateway refresh");
+    expect(report).not.toContain("Catalog fallback:");
+  });
+
   it("distinguishes a failed empty catalog from retained last-known models", () => {
     process.env.HOME = makeTempDir("gateway-home-");
     const ctx = {


### PR DESCRIPTION
## What this PR does

Reconciles SF LLM Gateway model-access state so explicit empty access removes stale selectable models, while recognized request/auth failures produce protocol-neutral recovery guidance.

## Why

A sentinel-only model listing was treated as a refresh failure, so Pi retained cached models that the active credential might no longer be allowed to use. Request-time access and configuration failures also surfaced raw or generic errors instead of telling users how to refresh, authenticate, or request access.

Related: #474

## How

- Treat only sentinel-only `no-default-models` discovery as an authoritative empty catalog; preserve callable peers and retain cache for ambiguous/network failures.
- Normalize `team_model_access_denied` and Pi's generic unconfigured-provider error through the public `message_end` replacement seam.
- Add explicit status, doctor, model-list, refresh, and access-telemetry guidance without silently switching models or rewriting settings.
- Add Behavior Proofs for cache clearing/recovery, mixed and ambiguous discovery, protocol-neutral diagnostics, status, doctor, and telemetry.

## Checklist

- [x] I ran `npm run validate` locally, or I listed the focused checks I ran below
- [x] I updated the affected extension's `README.md` (if behavior changed)
- [x] I added or updated tests
- [x] I regenerated the catalog (`npm run generate-catalog`) if I touched `manifest.json`
- [x] This PR is non-breaking, or I called out the breaking change explicitly above

## Security and public-surface checklist

- [x] I considered whether this adds or changes a high-value durable mutation exposed through an LLM-callable tool
- [x] Any high-value mutation is mediated by SF Guardrail, explicitly out of scope, or documented in an ADR/security note
- [x] Execution intent flags (for example `allow_mutation`, `allow_confirmed`, `mutation`, or `dry_run=false`) are not treated as approval
- [x] Headless execution for confirm-class operations fails closed unless explicitly operator-approved
- [x] Any operator auto-approve behavior is explicitly user/operator configured, narrowly scoped, audited, and does not bypass hard blocks
- [x] Public docs, examples, tests, comments, and diagnostics do not include secrets, customer names, real org/workspace identifiers, private hostnames, internal links, or copied private-source wording
- [x] New env vars, settings, provider labels, and examples use public-safe names and generic placeholders

## Validation performed

- Red proof: focused suite failed on all new access-state, request-diagnostic, status, doctor, telemetry, and lifecycle expectations before implementation.
- `npm exec vitest -- run extensions/sf-llm-gateway/tests` — 42 files, 417 tests passed.
- `npm run test:runtime-surface` — 30 tests passed.
- `npm run generate-catalog:check` — passed.
- `npm run format:check` — passed.
- `npm run check` — passed.
- `npm run lint` — passed.
- `npm run validate:ci` — 562 files passed, 1 skipped; 4,033 tests passed, 39 skipped.
- Pre-commit secret scan — no leaks found.
- Manual changed-file public-sanitization sweep — generic placeholder hosts only.

## Notes for reviewers

- This deliberately does not auto-refresh after a 403, silently switch the active conversation model, or mutate defaults, model scope, compaction preferences, or credentials.
- Sentinel-only discovery is security-first: it publishes an empty provider catalog. Ordinary empty responses and transport/service failures still retain the last-known cache.
- Existing architecture advisories remain unchanged; request diagnostics live in a dedicated module rather than expanding provider transport code.
