### PR TITLE
feat: treat Salesforce skills as supplemental playbooks

### DIFF
--- a/catalog/index.json
+++ b/catalog/index.json
@@ -906,7 +906,7 @@
     "entry": "extensions/sf-skills/index.ts",
     "hasReadme": true,
     "hasTests": true,
-    "srcLoc": 4711
+    "srcLoc": 4815
   },
   {
     "id": "sf-slack",
@@ -1137,6 +1137,6 @@
     "entry": "extensions/sf-welcome/index.ts",
     "hasReadme": true,
     "hasTests": true,
-    "srcLoc": 6644
+    "srcLoc": 6656
   }
 ]

--- a/extensions/sf-agentscript/AGENT_GUIDE.md
+++ b/extensions/sf-agentscript/AGENT_GUIDE.md
@@ -171,3 +171,8 @@ ordinary authoring turn.
 ## Production observability handoff
 
 When the user asks why a production agent behaved incorrectly, start with `sf-data360` observability data, then reproduce locally with `agentscript_preview`, fix via `agentscript_authoring`, verify with `agentscript_eval`, and ship with `agentscript_lifecycle`.
+
+## Related domain skills
+
+Prefer the Agent Script family tools when they can do the action. If they cannot, read one of these Salesforce skills:
+`agentforce-generate` · `agentforce-test` · `agentforce-observe` · `agentforce-architecture-analyze` · `agentforce-bot-upgrade`

--- a/extensions/sf-apex/AGENT_GUIDE.md
+++ b/extensions/sf-apex/AGENT_GUIDE.md
@@ -30,4 +30,5 @@ Use this guide for multi-step Apex authoring, diagnostics, logs, probes, and tes
 
 ## Related domain skills
 
-External Salesforce skills such as `generating-apex`, `generating-apex-test`, `running-apex-tests`, and `debugging-apex-logs` provide domain implementation guidance. They do not replace the `sf_apex` lifecycle surface.
+Prefer `sf_apex` when it can do the action. If it cannot, read one of these Salesforce skills:
+`platform-apex-generate` · `platform-apex-test-generate` · `platform-apex-test-run` · `platform-apex-logs-debug`

--- a/extensions/sf-brain/SF_CONSTITUTION.md
+++ b/extensions/sf-brain/SF_CONSTITUTION.md
@@ -3,7 +3,8 @@ You are a Salesforce-first software engineer. Optimize for correct behavior, min
 
 1. SALESFORCE-FIRST INTERPRETATION
 - In Salesforce contexts, interpret ambiguous objects, metadata, tests, releases, and runtime questions through Salesforce concepts first.
-- Use an active SF Pi tool that owns the workflow before external skills or raw sf CLI.
+- Use the active SF Pi family tool for the action (org evidence, lifecycle, artifacts).
+- Skills are supplemental playbooks for patterns, templates, and workflows the tools do not implement. They do not own the turn.
 - Follow explicit general engineering requests normally. Do not force Salesforce tools into unrelated work.
 
 2. SALESFORCE CHANGE AUTHORITY
@@ -47,5 +48,6 @@ You are a Salesforce-first software engineer. Optimize for correct behavior, min
   Slack → extensions/sf-slack/AGENT_GUIDE.md
   Salesforce diagrams → extensions/sf-tldraw/AGENT_GUIDE.md
   Herdr workflow lanes → extensions/sf-herdr/AGENT_GUIDE.md
-- External Salesforce skills remain independent domain playbooks. Do not treat them as bundled-extension operating manuals.
+- External Salesforce skills are supplemental. Read a skill body for implementation depth; do not treat it as the operating manual or as a reason to skip the family tool.
+- If a skill description says ALWAYS ACTIVATE or MUST activate, treat that as permission to read the playbook, not as permission to skip the family tool or to use raw CLI/MCP instead of it.
 </sf_engineering_constitution>

--- a/extensions/sf-brain/lib/routing-summary.ts
+++ b/extensions/sf-brain/lib/routing-summary.ts
@@ -37,8 +37,8 @@ export function formatSfPiRoutingSummary(cwd: string): string {
   );
   const lines = [
     SF_PI_ROUTING_OPEN_TAG,
-    "Use active SF Pi tools before external Salesforce skills or raw sf CLI.",
-    "Active tool definitions are authoritative for enabled capabilities.",
+    "Family tools perform the action. Skills are supplemental playbooks; they do not own the turn.",
+    "Active tool definitions are authoritative. Mix families when the task needs it. Raw sf CLI is a fallback only.",
   ];
   if (disabled.length === 0) {
     lines.push("Disabled capability owners: none.");

--- a/extensions/sf-brain/tests/routing-summary.test.ts
+++ b/extensions/sf-brain/tests/routing-summary.test.ts
@@ -54,7 +54,7 @@ describe("SF Pi Routing Summary", () => {
     expect(summary.startsWith(SF_PI_ROUTING_OPEN_TAG)).toBe(true);
     expect(summary.endsWith(SF_PI_ROUTING_CLOSE_TAG)).toBe(true);
     expect(summary).toContain(
-      "Use active SF Pi tools before external Salesforce skills or raw sf CLI.",
+      "Family tools perform the action. Skills are supplemental playbooks; they do not own the turn.",
     );
     expect(summary).toContain("Disabled capability owners: none.");
     expect(summary).not.toContain("Extension map:");

--- a/extensions/sf-browser/AGENT_GUIDE.md
+++ b/extensions/sf-browser/AGENT_GUIDE.md
@@ -50,3 +50,7 @@ For scroll, hover, drag, upload, tabs, state, console, network, eval, trace, vid
 ```bash
 agent-browser skills get core
 ```
+
+## Related domain skills
+
+Prefer `sf_browser_*` for Salesforce UI last-mile work. If it cannot cover the work, read the vendor skill `agent-browser` from vercel-labs/agent-browser.

--- a/extensions/sf-code-analyzer/AGENT_GUIDE.md
+++ b/extensions/sf-code-analyzer/AGENT_GUIDE.md
@@ -19,3 +19,8 @@ Use `code_analyzer` for explicit Salesforce static-analysis, rule discovery, con
 - `apexguru_setup_help` returns setup guidance. Do not start browser setup without user approval.
 - Code Analyzer never applies fixes automatically; use normal file tools after reviewing evidence.
 - Use `sf_apex`, `sf_lwc`, and `sf_soql` for lifecycle-specific runtime/test/schema proof.
+
+## Related domain skills
+
+Prefer `code_analyzer` when it can do the action. If it cannot, read one of these Salesforce skills:
+`dx-code-analyzer-run` · `dx-code-analyzer-configure` · `dx-code-analyzer-custom-rule-create` · `dx-apexguru-scan`

--- a/extensions/sf-data360/AGENT_GUIDE.md
+++ b/extensions/sf-data360/AGENT_GUIDE.md
@@ -35,3 +35,8 @@ evidence and must not drive public tool selection.
 ## Boundaries
 
 Use standard `sf_soql` for CRM SOQL. Use `data360_observe` for production Agentforce telemetry and Agent Script tools for local authoring/preview/eval. Do not hand-roll REST calls when a family action exists.
+
+## Related domain skills
+
+Prefer the `data360_*` family tool when it can do the action. If it cannot, read one of these Salesforce skills:
+`data360-connect` · `data360-prepare` · `data360-harmonize` · `data360-segment` · `data360-activate` · `data360-query` · `data360-orchestrate` · `data360-schema-get` · `data360-code-extension-generate` · `agentforce-d360-analyze` · `agentforce-observe`

--- a/extensions/sf-docs/AGENT_GUIDE.md
+++ b/extensions/sf-docs/AGENT_GUIDE.md
@@ -18,3 +18,8 @@ Use `sf_docs` for official Salesforce-owned documentation and product/reference 
 - Release-note requests require actual release-note evidence, not merely current-release metadata.
 - Fall back to broader web research only when official docs are missing, weak, or the user explicitly requests external sources.
 - Do not use SF Docs as a generic web search or as a substitute for current-org schema/runtime evidence.
+
+## Related domain skills
+
+Prefer `sf_docs` when it can do the action. If it cannot, read this Salesforce skill:
+`platform-docs-get`

--- a/extensions/sf-herdr/AGENT_GUIDE.md
+++ b/extensions/sf-herdr/AGENT_GUIDE.md
@@ -21,3 +21,7 @@ workflow is already running inside a ready Herdr pane.
 - Do not close panes that the current workflow did not create.
 - Sticky and manual lifecycles require explicit cleanup.
 - The official Herdr skill is separate and out of scope for SF Herdr.
+
+## Related domain skills
+
+Prefer `sf_herdr_plan` plus the vendor `herdr_layout` / `herdr_pane` / `herdr_agent` tools. If they cannot cover the work, read the vendor Herdr skill `herdr`.

--- a/extensions/sf-lwc/AGENT_GUIDE.md
+++ b/extensions/sf-lwc/AGENT_GUIDE.md
@@ -19,4 +19,7 @@ Use this guide for the local Lightning Web Component lifecycle. `sf_lwc` owns pr
 - Use Code Analyzer for broader static analysis and SLDS-specific guidance for SLDS 2 migrations.
 - Use SF Browser only when last-mile visual or Salesforce UI evidence is required.
 
-External `generating-lwc-components` guidance owns LWC implementation patterns; `sf_lwc` remains the evidence lifecycle.
+## Related domain skills
+
+Prefer `sf_lwc` when it can do the action. If it cannot, read one of these Salesforce skills:
+`experience-lwc-generate` · `experience-lwc-design-generate` · `experience-lwc-accessibility-validate` · `experience-lwc-security-validate` · `experience-lwc-rtl-validate` · `experience-lwc-typescript-migrate` · `experience-lwc-runtime-observe` · `experience-lwc-base-components-integrate` · `experience-aura-lwc-migrate`

--- a/extensions/sf-skills/README.md
+++ b/extensions/sf-skills/README.md
@@ -16,8 +16,10 @@ Pi remains the only skill loader; SF Skills compiles decisions into native
 `settings.skills[]` entries and never renames or edits `SKILL.md` files.
 
 It also provides an optional active-context HUD, the managed public Salesforce
-skill-library installer, explicit invocation counters, and stale-entry/orphan
-cleanup.
+skill-library installer (`forcedotcom/sf-skills`), explicit invocation counters,
+and stale-entry/orphan cleanup. A retired `forcedotcom/afv-library` checkout is
+detected and warned; `/sf-skills defaults install` switches wiring to the new
+library without deleting the old clone.
 
 ## Commands
 

--- a/extensions/sf-skills/index.ts
+++ b/extensions/sf-skills/index.ts
@@ -66,6 +66,7 @@ import {
   type ManagerDetailAction,
 } from "../../lib/common/manager-actions.ts";
 import { handleDefaults, parseDefaultsArgs } from "./lib/skills-command.ts";
+import { detectLegacyDefaultLibrary, formatLegacyDefaultLibraryWarning } from "./lib/defaults.ts";
 import { readEffectiveSfSkillsSettings } from "./lib/settings.ts";
 import { updateSkillSources } from "../../lib/common/skill-sources/skill-sources.ts";
 import { setSourceGate, upsertSource } from "../../lib/common/skill-sources/source-registry.ts";
@@ -233,7 +234,7 @@ function renderSkillsHelp(): string {
     "  • Conflicts — pick a winner (w) for resolvable name collisions",
     "  • enter applies staged changes, esc cancels",
     "",
-    "Defaults (forcedotcom/afv-library):",
+    "Defaults (forcedotcom/sf-skills):",
     "  • /sf-skills defaults install  [project|global]   (default: project; clones once, shared)",
     "  • /sf-skills defaults update   [project|global]",
     "  • /sf-skills defaults link <path> [project|global]",
@@ -243,7 +244,7 @@ function renderSkillsHelp(): string {
     "  /sf-skills           Open SF Skills in the SF Pi Manager",
     "  /sf-skills summary   HUD summary text",
     "  /sf-skills funnel    Open the skill funnel",
-    "  /sf-skills defaults  Manage afv-library installs (see above)",
+    "  /sf-skills defaults  Manage forcedotcom/sf-skills installs (see above)",
     "  /sf-skills help      Show this help",
   ].join("\n");
 }
@@ -335,10 +336,11 @@ export default function sfSkills(pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
     dismissOverlay();
     hudState = EMPTY_STATE;
-    if (ctx.mode !== "tui") {
-      return;
+    if (ctx.mode === "tui") {
+      const warning = formatLegacyDefaultLibraryWarning(detectLegacyDefaultLibrary(ctx.cwd));
+      if (warning) ctx.ui.notify(warning, "warning");
+      rebuildAndRender(ctx);
     }
-    rebuildAndRender(ctx);
   });
 
   pi.on("message_end", async (_event, ctx) => {

--- a/extensions/sf-skills/lib/catalog.ts
+++ b/extensions/sf-skills/lib/catalog.ts
@@ -363,7 +363,8 @@ function ensureCopy(
  */
 function fallbackSourceLabel(filePath: string): string {
   const norm = filePath.replace(/\\/g, "/");
-  if (norm.includes("/afv-library/")) return "afv-library";
+  if (norm.includes("/sf-skills/forcedotcom/")) return "sf-skills";
+  if (norm.includes("/afv-library/")) return "afv-library (legacy)";
   // …/<root>/<skill>/SKILL.md → name the <root> directory; for a loose
   // …/<root>/<name>.md → name the <root> directory too.
   const parts = norm.split("/").filter(Boolean);

--- a/extensions/sf-skills/lib/defaults.ts
+++ b/extensions/sf-skills/lib/defaults.ts
@@ -1,17 +1,17 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /**
- * forcedotcom/afv-library install / update / link / unlink.
+ * forcedotcom/sf-skills install / update / link / unlink.
  *
  * Why this module exists
  * ----------------------
  * The Salesforce community publishes a curated skill library at
- * `forcedotcom/afv-library`. Users who want those skills should not have
+ * `forcedotcom/sf-skills`. Users who want those skills should not have
  * to clone manually and edit `settings.json` by hand. This module owns
  * that lifecycle:
  *
  *   install : git clone the repo into a managed dir + wire it into settings
  *   update  : git pull --ff-only on managed dirs only (sentinel-gated)
- *   link    : wire a user-owned checkout (e.g. ~/work/afv-library) into settings
+ *   link    : wire a user-owned checkout (e.g. ~/work/sf-skills) into settings
  *   unlink  : remove a wired entry; --delete only valid on managed dirs
  *   status  : report every known managed/linked checkout
  *
@@ -40,8 +40,11 @@ import {
 // Constants
 // -------------------------------------------------------------------------------------------------
 
-const REPO_URL = "https://github.com/forcedotcom/afv-library";
-const REPO_DIR_NAME = "afv-library";
+export const DEFAULT_LIBRARY_REPO_URL = "https://github.com/forcedotcom/sf-skills";
+export const DEFAULT_LIBRARY_DIR_NAME = "forcedotcom";
+export const LEGACY_LIBRARY_DIR_NAME = "afv-library";
+const REPO_URL = DEFAULT_LIBRARY_REPO_URL;
+const REPO_DIR_NAME = DEFAULT_LIBRARY_DIR_NAME;
 const SKILLS_SUBDIR = "skills";
 const SENTINEL_FILE = ".sf-skills-managed";
 
@@ -87,8 +90,8 @@ export interface UpdateResult {
 /**
  * Resolve the managed clone path for a scope.
  *
- * Global: `~/.pi/agent/sf-skills/afv-library/`
- * Project: `<cwd>/.pi/sf-skills/afv-library/`
+ * Global: `~/.pi/agent/sf-skills/forcedotcom/`
+ * Project: `<cwd>/.pi/sf-skills/forcedotcom/`
  *
  * Both live OUTSIDE pi's auto-discovery roots so wiring stays the
  * single source of truth.
@@ -138,6 +141,53 @@ export function inspectManagedClone(scope: SkillSourceScope, cwd?: string): Mana
   return { rootPath, skillsPath, settingsValue, scope, exists, managed, wired };
 }
 
+export function legacyManagedClonePath(scope: SkillSourceScope, cwd?: string): string {
+  if (scope === "project") {
+    if (!cwd) throw new Error("legacyManagedClonePath: cwd is required for scope='project'");
+    return projectConfigPath(cwd, "sf-skills", LEGACY_LIBRARY_DIR_NAME);
+  }
+  return globalAgentPath("sf-skills", LEGACY_LIBRARY_DIR_NAME);
+}
+
+export function legacyManagedSettingsValue(): string {
+  return `~/.pi/agent/sf-skills/${LEGACY_LIBRARY_DIR_NAME}/${SKILLS_SUBDIR}`;
+}
+
+export interface LegacyDefaultLibraryDetection {
+  clones: Array<{ scope: SkillSourceScope; rootPath: string; exists: boolean; wired: boolean }>;
+  present: boolean;
+  wired: boolean;
+}
+
+/** Detect retired forcedotcom/afv-library clones or wiring. Cheap path/settings checks only. */
+export function detectLegacyDefaultLibrary(cwd?: string): LegacyDefaultLibraryDetection {
+  const clones: LegacyDefaultLibraryDetection["clones"] = [];
+  for (const scope of ["global", "project"] as const) {
+    if (scope === "project" && !cwd) continue;
+    const rootPath = legacyManagedClonePath(scope, cwd);
+    const skillsPath = path.join(rootPath, SKILLS_SUBDIR);
+    const exists = isDirectory(rootPath);
+    const wired = settingsMentionLegacy(scope, cwd, skillsPath);
+    clones.push({ scope, rootPath, exists, wired });
+  }
+  return {
+    clones,
+    present: clones.some((clone) => clone.exists || clone.wired),
+    wired: clones.some((clone) => clone.wired),
+  };
+}
+
+export function formatLegacyDefaultLibraryWarning(
+  detection: LegacyDefaultLibraryDetection = detectLegacyDefaultLibrary(),
+): string | undefined {
+  if (!detection.present) return undefined;
+  return [
+    "Retired Salesforce skill library detected (forcedotcom/afv-library).",
+    "SF Pi now installs forcedotcom/sf-skills (platform-apex-generate, not generating-apex).",
+    "Run /sf-skills defaults install to switch. The old clone stays on disk until you unlink --delete.",
+  ].join(" ");
+}
+
 // -------------------------------------------------------------------------------------------------
 // Install
 // -------------------------------------------------------------------------------------------------
@@ -158,7 +208,7 @@ export interface InstallOptions {
 }
 
 /**
- * Ensure the afv-library clone exists (once, globally) and wire it into the
+ * Ensure the forcedotcom/sf-skills clone exists (once, globally) and wire it into the
  * chosen scope's `settings.skills[]`. Content lives global + shared; wiring is
  * the scoping lever (local-first by default). Idempotent.
  */
@@ -191,6 +241,7 @@ export async function installDefaults(options: InstallOptions): Promise<InstallR
   }
 
   const alreadyWired = isManagedWired(wireScope, options.cwd, content.skillsPath);
+  const legacyRemoved = unwireLegacyDefaultLibrary(wireScope, options.cwd);
   if (!alreadyWired) {
     updateSkillSources({
       add: [settingsValue],
@@ -209,12 +260,16 @@ export async function installDefaults(options: InstallOptions): Promise<InstallR
     wired: isManagedWired(wireScope, options.cwd, content.skillsPath),
   };
   const wiredVerb = alreadyWired ? "still wired" : "now wired";
+  const installed = content.exists
+    ? `Already cloned at ${next.rootPath}; ${wiredVerb} in ${wireScope} settings.`
+    : `Cloned forcedotcom/sf-skills into ${next.rootPath} and wired it in ${wireScope} settings.`;
+  const legacyNote = legacyRemoved
+    ? " Removed retired forcedotcom/afv-library wiring from this scope."
+    : formatLegacyDefaultLibraryWarning(detectLegacyDefaultLibrary(options.cwd));
   return {
     ok: true,
     clone,
-    message: content.exists
-      ? `Already cloned at ${next.rootPath}; ${wiredVerb} in ${wireScope} settings.`
-      : `Cloned afv-library into ${next.rootPath} and wired it in ${wireScope} settings.`,
+    message: legacyNote ? `${installed} ${legacyNote}` : installed,
   };
 }
 
@@ -228,6 +283,39 @@ function isManagedWired(
   const settingsPath = scope === "project" ? detection.projectSettingsPath : detection.settingsPath;
   if (!settingsPath) return false;
   return readSkillsArray(settingsPath).some((value) => resolvesToSamePath(value, skillsPath, cwd));
+}
+
+function settingsMentionLegacy(
+  scope: SkillSourceScope,
+  cwd: string | undefined,
+  skillsPath: string,
+): boolean {
+  const detection = detectSkillSources({ cwd, includeProject: scope === "project" });
+  const settingsPath = scope === "project" ? detection.projectSettingsPath : detection.settingsPath;
+  if (!settingsPath) return false;
+  return readSkillsArray(settingsPath).some(
+    (value) =>
+      value.includes(LEGACY_LIBRARY_DIR_NAME) || resolvesToSamePath(value, skillsPath, cwd),
+  );
+}
+
+function unwireLegacyDefaultLibrary(scope: SkillSourceScope, cwd?: string): boolean {
+  const detection = detectSkillSources({ cwd, includeProject: scope === "project" });
+  const settingsPath = scope === "project" ? detection.projectSettingsPath : detection.settingsPath;
+  if (!settingsPath) return false;
+  const toRemove = readSkillsArray(settingsPath).filter((value) =>
+    value.includes(LEGACY_LIBRARY_DIR_NAME),
+  );
+  if (toRemove.length === 0) return false;
+  updateSkillSources({ add: [], remove: toRemove, scope, cwd });
+  return true;
+}
+
+function legacyUpdateMissingMessage(cwd?: string): string {
+  const warning = formatLegacyDefaultLibraryWarning(detectLegacyDefaultLibrary(cwd));
+  return warning
+    ? `${warning}`
+    : "No managed forcedotcom/sf-skills clone found. Run /sf-skills defaults install first.";
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -250,7 +338,7 @@ export async function updateDefaults(options: UpdateOptions): Promise<UpdateResu
     return {
       ok: false,
       clone,
-      message: "No managed afv-library clone found. Run install first.",
+      message: legacyUpdateMissingMessage(options.cwd),
       output: "",
     };
   }
@@ -270,7 +358,7 @@ export async function updateDefaults(options: UpdateOptions): Promise<UpdateResu
     ok: result.success,
     clone,
     message: result.success
-      ? "Pulled latest afv-library."
+      ? "Pulled latest forcedotcom/sf-skills."
       : `git pull failed: ${result.stderr || result.stdout || "unknown error"}`,
     output: `${result.stdout}${result.stderr ? `\n${result.stderr}` : ""}`,
   };
@@ -281,7 +369,7 @@ export async function updateDefaults(options: UpdateOptions): Promise<UpdateResu
 // -------------------------------------------------------------------------------------------------
 
 export interface LinkOptions {
-  /** Absolute or `~`-prefixed path to a user-owned afv-library checkout. */
+  /** Absolute or `~`-prefixed path to a user-owned sf-skills checkout. */
   checkoutPath: string;
   scope: SkillSourceScope;
   cwd?: string;
@@ -302,7 +390,7 @@ export function linkExistingCheckout(options: LinkOptions): { ok: boolean; messa
   if (!isDirectory(skillsDir)) {
     return {
       ok: false,
-      message: `Expected a 'skills/' subdir inside ${expanded}; this does not look like an afv-library checkout.`,
+      message: `Expected a 'skills/' subdir inside ${expanded}; this does not look like a Salesforce skills checkout.`,
     };
   }
   const settingsValue = portableLinkValue(options.checkoutPath, options.scope, options.cwd);

--- a/extensions/sf-skills/lib/gather.ts
+++ b/extensions/sf-skills/lib/gather.ts
@@ -185,24 +185,39 @@ function buildSources(args: BuildSourcesArgs): CatalogSourceInput[] {
     add(defaultRoot(path.join(args.cwd, ".agents", "skills"), ".agents (project)"));
   }
 
-  // 1b. The curated afv-library managed clone lives at a well-known location at
-  // each scope. Recognize it explicitly so installs that predate the Source
-  // Registry (and per-file wirings under it) are labelled "afv-library" instead
-  // of "Unknown source", and stay visible even when fully disabled.
+  // 1b. Managed default-library clones live at well-known locations. Recognize
+  // the current forcedotcom/sf-skills clone and the retired afv-library path so
+  // neither is labelled "Unknown source", and both stay visible when unwired.
   add({
-    id: "afv-library (global)",
+    id: "sf-skills (global)",
+    rootPath: path.join(args.agentDir, "sf-skills", "forcedotcom", "skills"),
+    kind: "managed",
+    label: "sf-skills (global)",
+    gate: "seen",
+    autoDefault: false,
+  });
+  add({
+    id: "afv-library (legacy, global)",
     rootPath: path.join(args.agentDir, "sf-skills", "afv-library", "skills"),
     kind: "managed",
-    label: "afv-library (global)",
+    label: "afv-library (legacy, global)",
     gate: "seen",
     autoDefault: false,
   });
   if (args.projectTrusted) {
     add({
-      id: "afv-library (project)",
+      id: "sf-skills (project)",
+      rootPath: path.join(args.cwd, ".pi", "sf-skills", "forcedotcom", "skills"),
+      kind: "managed",
+      label: "sf-skills (project)",
+      gate: "seen",
+      autoDefault: false,
+    });
+    add({
+      id: "afv-library (legacy, project)",
       rootPath: path.join(args.cwd, ".pi", "sf-skills", "afv-library", "skills"),
       kind: "managed",
-      label: "afv-library (project)",
+      label: "afv-library (legacy, project)",
       gate: "seen",
       autoDefault: false,
     });

--- a/extensions/sf-skills/lib/skills-command.ts
+++ b/extensions/sf-skills/lib/skills-command.ts
@@ -20,6 +20,8 @@ import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { openInfoPanel } from "../../../lib/common/info-panel.ts";
 import type { SkillSourceScope } from "../../../lib/common/skill-sources/skill-sources.ts";
 import {
+  detectLegacyDefaultLibrary,
+  formatLegacyDefaultLibraryWarning,
   inspectManagedClone,
   installDefaults,
   linkExistingCheckout,
@@ -123,7 +125,7 @@ export async function handleDefaults(
       return;
 
     case "install": {
-      ctx.ui.notify(`Installing afv-library (${args.scope})…`, "info");
+      ctx.ui.notify(`Installing forcedotcom/sf-skills (${args.scope})…`, "info");
       const result = await installDefaults({ scope: args.scope, cwd: ctx.cwd });
       if (!result.ok) {
         await emit("Install failed", result.message, "warning");
@@ -135,7 +137,7 @@ export async function handleDefaults(
     }
 
     case "update": {
-      ctx.ui.notify(`Updating afv-library (${args.scope})…`, "info");
+      ctx.ui.notify(`Updating forcedotcom/sf-skills (${args.scope})…`, "info");
       const result = await updateDefaults({ scope: args.scope, cwd: ctx.cwd });
       if (!result.ok) {
         await emit("Update failed", result.message, "warning");
@@ -153,7 +155,7 @@ export async function handleDefaults(
       if (!args.target) {
         await emit(
           "Usage",
-          "/sf-skills defaults link <path> [project|global]\nExample: /sf-skills defaults link ~/work/afv-library",
+          "/sf-skills defaults link <path> [project|global]\nExample: /sf-skills defaults link ~/work/sf-skills",
           "warning",
         );
         return;
@@ -176,7 +178,7 @@ export async function handleDefaults(
       if (!args.target) {
         await emit(
           "Usage",
-          "/sf-skills defaults unlink <path> [project|global] [--delete]\nExample: /sf-skills defaults unlink ~/work/afv-library --delete",
+          "/sf-skills defaults unlink <path> [project|global] [--delete]\nExample: /sf-skills defaults unlink ~/work/sf-skills --delete",
           "warning",
         );
         return;
@@ -203,7 +205,11 @@ export async function handleDefaults(
 // -------------------------------------------------------------------------------------------------
 
 function renderStatus(cwd: string, opts: { includeProject: boolean }): string {
-  const lines: string[] = ["forcedotcom/afv-library managed checkouts:", ""];
+  const lines: string[] = ["forcedotcom/sf-skills managed checkouts:", ""];
+  const legacyWarning = formatLegacyDefaultLibraryWarning(detectLegacyDefaultLibrary(cwd));
+  if (legacyWarning) {
+    lines.push(`WARNING: ${legacyWarning}`, "");
+  }
   for (const scope of ["global", "project"] as const) {
     if (scope === "project" && !opts.includeProject) {
       lines.push("PROJECT");

--- a/extensions/sf-skills/tests/defaults.test.ts
+++ b/extensions/sf-skills/tests/defaults.test.ts
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /**
- * Tests for the afv-library defaults installer (no real git, no real network).
+ * Tests for the forcedotcom/sf-skills defaults installer (no real git, no real network).
  *
  * We inject a fake spawn impl so install/update can simulate clone/pull
  * outcomes deterministically. Only the ManagedClone state machine and
@@ -11,6 +11,8 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
+  detectLegacyDefaultLibrary,
+  formatLegacyDefaultLibraryWarning,
   inspectManagedClone,
   installDefaults,
   managedClonePath,
@@ -132,7 +134,7 @@ describe("inspectManagedClone", () => {
     process.env.HOME = home;
     const cwd = makeCwd();
     expect(managedClonePath("project", cwd)).toBe(
-      path.join(cwd, ".pi", "sf-skills", "afv-library"),
+      path.join(cwd, ".pi", "sf-skills", "forcedotcom"),
     );
   });
 });
@@ -152,7 +154,7 @@ describe("installDefaults (with fake git)", () => {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       require("node:fs").readFileSync(path.join(home, ".pi", "agent", "settings.json"), "utf8"),
     );
-    expect(settings.skills).toContain("~/.pi/agent/sf-skills/afv-library/skills");
+    expect(settings.skills).toContain("~/.pi/agent/sf-skills/forcedotcom/skills");
   });
 
   it("is idempotent on second invocation", async () => {
@@ -171,7 +173,7 @@ describe("installDefaults (with fake git)", () => {
     const result = await installDefaults({ scope: "project", cwd, spawn: fakeGit });
     expect(result.ok).toBe(true);
     // Content is the single global clone — never a per-project clone.
-    expect(result.clone.rootPath).toBe(path.join(home, ".pi", "agent", "sf-skills", "afv-library"));
+    expect(result.clone.rootPath).toBe(path.join(home, ".pi", "agent", "sf-skills", "forcedotcom"));
     expect(result.clone.scope).toBe("project");
     expect(result.clone.wired).toBe(true);
 
@@ -179,9 +181,9 @@ describe("installDefaults (with fake git)", () => {
     const fs = require("node:fs");
     // Project settings reference the GLOBAL clone path (local-first enablement).
     const settings = JSON.parse(fs.readFileSync(path.join(cwd, ".pi", "settings.json"), "utf8"));
-    expect(settings.skills).toContain("~/.pi/agent/sf-skills/afv-library/skills");
+    expect(settings.skills).toContain("~/.pi/agent/sf-skills/forcedotcom/skills");
     // No per-project clone was created.
-    expect(fs.existsSync(path.join(cwd, ".pi", "sf-skills", "afv-library"))).toBe(false);
+    expect(fs.existsSync(path.join(cwd, ".pi", "sf-skills", "forcedotcom"))).toBe(false);
     // Global settings were not written (only project scope was wired).
     expect(fs.existsSync(path.join(home, ".pi", "agent", "settings.json"))).toBe(false);
   });
@@ -193,13 +195,13 @@ describe("updateDefaults", () => {
     process.env.HOME = home;
     const result = await updateDefaults({ scope: "global", spawn: fakeGit });
     expect(result.ok).toBe(false);
-    expect(result.message).toMatch(/No managed afv-library/);
+    expect(result.message).toMatch(/No managed forcedotcom\/sf-skills/);
   });
 
   it("refuses to pull a checkout missing the sentinel", async () => {
     const home = makeHome();
     process.env.HOME = home;
-    const root = path.join(home, ".pi", "agent", "sf-skills", "afv-library");
+    const root = path.join(home, ".pi", "agent", "sf-skills", "forcedotcom");
     mkdirSync(path.join(root, "skills"), { recursive: true });
     // No sentinel file.
     const result = await updateDefaults({ scope: "global", spawn: fakeGit });
@@ -223,7 +225,7 @@ describe("unlinkCheckout", () => {
     await installDefaults({ scope: "global", spawn: fakeGit });
 
     const result = unlinkCheckout({
-      target: "~/.pi/agent/sf-skills/afv-library/skills",
+      target: "~/.pi/agent/sf-skills/forcedotcom/skills",
       scope: "global",
     });
     expect(result.ok).toBe(true);
@@ -233,7 +235,7 @@ describe("unlinkCheckout", () => {
     const settings = JSON.parse(
       fs.readFileSync(path.join(home, ".pi", "agent", "settings.json"), "utf8"),
     );
-    expect(settings.skills).not.toContain("~/.pi/agent/sf-skills/afv-library/skills");
+    expect(settings.skills).not.toContain("~/.pi/agent/sf-skills/forcedotcom/skills");
   });
 
   it("refuses to delete a path missing the sentinel", () => {
@@ -251,5 +253,48 @@ describe("unlinkCheckout", () => {
     // the literal word “sentinel” — match on the filename so the test stays
     // honest about what the user actually sees.
     expect(result.message).toMatch(/\.sf-skills-managed/);
+  });
+});
+
+describe("legacy afv-library detection", () => {
+  it("warns when a retired clone exists or is wired", () => {
+    const home = makeHome();
+    process.env.HOME = home;
+    const root = path.join(home, ".pi", "agent", "sf-skills", "afv-library");
+    mkdirSync(path.join(root, "skills"), { recursive: true });
+    mkdirSync(path.join(home, ".pi", "agent"), { recursive: true });
+    writeFileSync(
+      path.join(home, ".pi", "agent", "settings.json"),
+      `${JSON.stringify({ skills: ["~/.pi/agent/sf-skills/afv-library/skills"] })}\n`,
+    );
+
+    const detection = detectLegacyDefaultLibrary();
+    expect(detection.present).toBe(true);
+    expect(detection.wired).toBe(true);
+    expect(formatLegacyDefaultLibraryWarning(detection)).toMatch(/forcedotcom\/afv-library/);
+  });
+
+  it("unwires the retired library when installing the new default", async () => {
+    const home = makeHome();
+    process.env.HOME = home;
+    mkdirSync(path.join(home, ".pi", "agent", "sf-skills", "afv-library", "skills"), {
+      recursive: true,
+    });
+    mkdirSync(path.join(home, ".pi", "agent"), { recursive: true });
+    writeFileSync(
+      path.join(home, ".pi", "agent", "settings.json"),
+      `${JSON.stringify({ skills: ["~/.pi/agent/sf-skills/afv-library/skills"] })}\n`,
+    );
+
+    const result = await installDefaults({ scope: "global", spawn: fakeGit });
+    expect(result.ok).toBe(true);
+    expect(result.message).toMatch(/Removed retired forcedotcom\/afv-library/);
+
+    const settings = JSON.parse(
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require("node:fs").readFileSync(path.join(home, ".pi", "agent", "settings.json"), "utf8"),
+    );
+    expect(settings.skills).toContain("~/.pi/agent/sf-skills/forcedotcom/skills");
+    expect(settings.skills).not.toContain("~/.pi/agent/sf-skills/afv-library/skills");
   });
 });

--- a/extensions/sf-skills/tests/gather.test.ts
+++ b/extensions/sf-skills/tests/gather.test.ts
@@ -183,7 +183,7 @@ describe("gatherCatalogInput", () => {
     const afv = input.sources.find((s) => s.rootPath === path.normalize(afvRoot));
     expect(afv).toBeDefined();
     expect(afv!.kind).toBe("managed");
-    expect(afv!.label).toBe("afv-library (global)");
+    expect(afv!.label).toBe("afv-library (legacy, global)");
     expect(afv!.gate).toBe("seen");
     expect(afv!.skills.map((s) => s.name).sort()).toEqual([
       "deploying-metadata",

--- a/extensions/sf-soql/AGENT_GUIDE.md
+++ b/extensions/sf-soql/AGENT_GUIDE.md
@@ -24,3 +24,8 @@ Use this guide for schema-aware CRM SOQL/SOSL work. `sf_soql` owns discovery, va
 ## Evidence
 
 Validation, query-plan signals, samples, counts, and artifact paths are the Behavior Proof. Never infer query correctness from syntax alone when current org schema is available.
+
+## Related domain skills
+
+Prefer `sf_soql` when it can do the action. If it cannot, read one of these Salesforce skills:
+`platform-soql-query` · `platform-data-manage`

--- a/extensions/sf-tldraw/AGENT_GUIDE.md
+++ b/extensions/sf-tldraw/AGENT_GUIDE.md
@@ -18,3 +18,7 @@ Use `tldraw_canvas` for deterministic, editable Salesforce data-model, architect
 - Use `cheatsheet` only when the spec contract is needed.
 - Do not use OS automation or direct `.tldraw` archive generation as a fallback.
 - Explicit Mermaid/text requests take priority over Canvas rendering.
+
+## Related domain skills
+
+Prefer `tldraw_canvas` for Salesforce canvas diagrams. If it cannot cover the work, read the vendor tldraw skill `tldraw-offline`. For text Mermaid instead of a canvas, read `external-diagram-mermaid-generate`.

--- a/extensions/sf-welcome/lib/sf-skills-status.ts
+++ b/extensions/sf-welcome/lib/sf-skills-status.ts
@@ -1,15 +1,15 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /**
- * forcedotcom/afv-library install + freshness status for the welcome splash.
+ * forcedotcom/sf-skills install + freshness status for the welcome splash.
  *
  * The companion `sf-skills` extension owns the install / update / link
  * lifecycle. This module is a strictly read-only sibling that surfaces a
  * single splash row:
  *
- *     📚 SF Skills    ✓ afv-library installed · latest
- *     📚 SF Skills    ✓ afv-library available
- *     📚 SF Skills    ↑ afv-library · 12 commits behind
- *     📚 SF Skills    ✓ afv-library linked · ~/work/afv-library
+ *     📚 SF Skills    ✓ sf-skills installed · latest
+ *     📚 SF Skills    ✓ sf-skills available
+ *     📚 SF Skills    ↑ sf-skills · 12 commits behind
+ *     📚 SF Skills    ✓ sf-skills linked · ~/work/sf-skills
  *     📚 SF Skills    ↑ Install official skills (·  /sf-skills defaults install)
  *
  * Design rules (must hold so startup time stays flat):
@@ -35,7 +35,7 @@ import path from "node:path";
 import { homedir } from "node:os";
 import { createStateStore } from "../../../lib/common/state-store.ts";
 import { globalSettingsPath, projectSettingsPath } from "../../../lib/common/pi-paths.ts";
-import { managedClonePath } from "../../sf-skills/lib/defaults.ts";
+import { legacyManagedClonePath, managedClonePath } from "../../sf-skills/lib/defaults.ts";
 import type { SfSkillsStatusInfo } from "./types.ts";
 
 // -------------------------------------------------------------------------------------------------
@@ -43,7 +43,7 @@ import type { SfSkillsStatusInfo } from "./types.ts";
 // -------------------------------------------------------------------------------------------------
 
 const REPO_OWNER = "forcedotcom";
-const REPO_NAME = "afv-library";
+const REPO_NAME = "sf-skills";
 const REPO_DEFAULT_BRANCH = "main";
 const GITHUB_COMPARE_TIMEOUT_MS = 5_000;
 const CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
@@ -326,9 +326,16 @@ function detectManagedWiring(
 function managedCloneAvailability(
   scope: "global" | "project",
   cwd: string,
+  kind: "current" | "legacy" = "current",
 ): { rootPath: string; skillsPath: string; scope: "global" | "project"; wired: boolean } | null {
   const rootPath =
-    scope === "project" ? managedClonePath("project", cwd) : managedClonePath("global");
+    kind === "legacy"
+      ? scope === "project"
+        ? legacyManagedClonePath("project", cwd)
+        : legacyManagedClonePath("global")
+      : scope === "project"
+        ? managedClonePath("project", cwd)
+        : managedClonePath("global");
   if (!isDirectory(rootPath)) return null;
   if (!existsSync(path.join(rootPath, MANAGED_SENTINEL_FILE))) return null;
   const skillsPath = path.join(rootPath, SKILLS_SUBDIR);
@@ -344,7 +351,12 @@ function managedCloneAvailability(
 function findManagedSourceAvailability(
   cwd: string,
 ): { rootPath: string; skillsPath: string; scope: "global" | "project"; wired: boolean } | null {
-  return managedCloneAvailability("global", cwd) ?? managedCloneAvailability("project", cwd);
+  return (
+    managedCloneAvailability("global", cwd, "current") ??
+    managedCloneAvailability("project", cwd, "current") ??
+    managedCloneAvailability("global", cwd, "legacy") ??
+    managedCloneAvailability("project", cwd, "legacy")
+  );
 }
 
 /**

--- a/extensions/sf-welcome/lib/splash-component.ts
+++ b/extensions/sf-welcome/lib/splash-component.ts
@@ -436,7 +436,7 @@ function formatSfSkillsStatusValue(data: SplashData, mode: GlyphMode): string {
   // buildLeftColumn) so the row text itself stays inside the 72-col
   // left-column cap that the SALESFORCE wordmark drives.
   if (skills.installKind === "not-installed") {
-    return `${SF_ORANGE("↑")} ${SF_ORANGE("Install official skills")} ${MUTED("· afv-library · this project")}`;
+    return `${SF_ORANGE("↑")} ${SF_ORANGE("Install official skills")} ${MUTED("· sf-skills · this project")}`;
   }
 
   const skillCountSuffix =
@@ -446,7 +446,7 @@ function formatSfSkillsStatusValue(data: SplashData, mode: GlyphMode): string {
 
   if (skills.installKind === "linked") {
     // User-owned checkout: green ✓, never nag for updates.
-    return `${SF_GREEN("✓")} ${SF_GREEN("afv-library linked")}${skillCountSuffix}`;
+    return `${SF_GREEN("✓")} ${SF_GREEN("sf-skills linked")}${skillCountSuffix}`;
   }
 
   // installKind === "managed"
@@ -455,10 +455,10 @@ function formatSfSkillsStatusValue(data: SplashData, mode: GlyphMode): string {
       typeof skills.commitsBehind === "number" && skills.commitsBehind > 0
         ? `${skills.commitsBehind} commit${skills.commitsBehind === 1 ? "" : "s"} behind`
         : "update available";
-    return `${SF_ORANGE("↑")} ${SF_ORANGE("afv-library")} ${MUTED(`· ${behind}`)}`;
+    return `${SF_ORANGE("↑")} ${SF_ORANGE("sf-skills")} ${MUTED(`· ${behind}`)}`;
   }
 
-  const managedLabel = skills.wired === false ? "afv-library available" : "afv-library installed";
+  const managedLabel = skills.wired === false ? "sf-skills available" : "sf-skills installed";
 
   if (skills.freshness === "latest") {
     return `${SF_GREEN("✓")} ${SF_GREEN(managedLabel)} ${MUTED("· latest")}${skillCountSuffix}`;
@@ -1063,7 +1063,7 @@ function buildLeftColumn(
     lines.push(`   ${MUTED(`→ ${truncated}`)}`);
   }
 
-  // SF Skills (forcedotcom/afv-library) install + freshness. Always
+  // SF Skills (forcedotcom/sf-skills) install + freshness. Always
   // rendered — the not-installed state is the loud orange nudge that
   // pushes users toward the official skills library. Cache-first paint
   // (see sf-skills-status.ts) keeps this row free at startup.

--- a/extensions/sf-welcome/lib/types.ts
+++ b/extensions/sf-welcome/lib/types.ts
@@ -69,12 +69,12 @@ export interface ReleaseStatusInfo {
 }
 
 /**
- * How the official forcedotcom/afv-library skills repo is available to the
+ * How the official forcedotcom/sf-skills repo is available to the
  * current pi install.
  *
  *   managed       — cloned + sentinel-marked by `/sf-skills defaults install`
  *   linked        — user-owned checkout wired via `/sf-skills defaults link`
- *   not-installed — no afv-library entry found in either scope
+ *   not-installed — no official skills library entry found in either scope
  */
 export type SfSkillsInstallKind = "managed" | "linked" | "not-installed";
 
@@ -341,7 +341,7 @@ export interface SplashData {
   autoUpdate?: AutoUpdateStatusInfo;
   /** External agent-browser runtime install/freshness status used by SF Browser. */
   browserRuntime?: BrowserRuntimeStatusInfo;
-  /** Lightweight forcedotcom/afv-library install + freshness status
+  /** Lightweight forcedotcom/sf-skills install + freshness status
    *  populated asynchronously after initial render. Mirrors the sfCli
    *  cache-first → deferred-refresh pattern; never blocks startup. */
   sfSkills?: SfSkillsStatusInfo;

--- a/extensions/sf-welcome/tests/sf-skills-status.test.ts
+++ b/extensions/sf-welcome/tests/sf-skills-status.test.ts
@@ -190,7 +190,7 @@ describe("detectLinkedAfvCheckout", () => {
 
 describe("detectInstallStateLocal", () => {
   function createManagedGlobal(): { rootPath: string; skillsPath: string } {
-    const rootPath = path.join(tmpDir, "sf-skills", "afv-library");
+    const rootPath = path.join(tmpDir, "sf-skills", "forcedotcom");
     const skillsPath = path.join(rootPath, "skills");
     mkdirSync(skillsPath, { recursive: true });
     mkdirSync(path.join(rootPath, ".git", "refs", "heads"), { recursive: true });
@@ -323,7 +323,7 @@ describe("detectInstallStateLocal", () => {
 
 describe("detectSfSkillsStatus", () => {
   function setupManagedGlobal(localSha: string): void {
-    const rootPath = path.join(tmpDir, "sf-skills", "afv-library");
+    const rootPath = path.join(tmpDir, "sf-skills", "forcedotcom");
     const skillsPath = path.join(rootPath, "skills");
     mkdirSync(skillsPath, { recursive: true });
     mkdirSync(path.join(rootPath, ".git", "refs", "heads"), { recursive: true });

--- a/extensions/sf-welcome/tests/splash-sf-skills.test.ts
+++ b/extensions/sf-welcome/tests/splash-sf-skills.test.ts
@@ -83,7 +83,7 @@ describe("SF Skills splash row render states", () => {
     expect(row).toContain("SF Skills");
     expect(row).toContain("↑");
     expect(row).toContain("Install official skills");
-    expect(row).toContain("afv-library");
+    expect(row).toContain("sf-skills");
     // The actionable command lives on the muted sub-line so the row stays
     // inside the column-width cap.
     expect(hint).not.toBeNull();
@@ -101,7 +101,7 @@ describe("SF Skills splash row render states", () => {
       loading: false,
     });
     expect(row).toContain("✓");
-    expect(row).toContain("afv-library available");
+    expect(row).toContain("sf-skills available");
     expect(row).not.toContain("Install official skills");
     expect(hint).not.toBeNull();
     expect(hint).toContain("/sf-skills defaults install");
@@ -141,7 +141,7 @@ describe("SF Skills splash row render states", () => {
       loading: false,
     });
     expect(row).toContain("✓");
-    expect(row).toContain("afv-library installed");
+    expect(row).toContain("sf-skills installed");
     expect(row).toContain("latest");
     expect(row).toContain("53 skills");
     // Nothing actionable on this state — no sub-line.
@@ -162,7 +162,7 @@ describe("SF Skills splash row render states", () => {
       loading: false,
     });
     expect(row).toContain("↑");
-    expect(row).toContain("afv-library");
+    expect(row).toContain("sf-skills");
     expect(row).toContain("12 commits behind");
     expect(hint).not.toBeNull();
     expect(hint).toContain("/sf-skills defaults update");
@@ -197,7 +197,7 @@ describe("SF Skills splash row render states", () => {
       loading: false,
     });
     expect(row).toContain("✓");
-    expect(row).toContain("afv-library linked");
+    expect(row).toContain("sf-skills linked");
     expect(row).toContain("7 skills");
     // Linked rows never carry the orange ↑ — they're user-owned working trees.
     expect(row).not.toContain("↑");
@@ -218,7 +218,7 @@ describe("SF Skills splash row render states", () => {
       loading: false,
     });
     expect(row).toContain("✓");
-    expect(row).toContain("afv-library installed");
+    expect(row).toContain("sf-skills installed");
     expect(row).not.toContain("↑");
     expect(row).not.toContain("Update");
     expect(hint).toBeNull();


### PR DESCRIPTION
## Summary
- Family tools perform the action; skills are supplemental playbooks that fill gaps.
- Constitution and routing no longer say "tools before skills." Guides name current `forcedotcom/sf-skills` fallbacks plus vendor skills for tldraw, Herdr, and agent-browser.
- Managed installer now clones `forcedotcom/sf-skills`. A retired `afv-library` checkout is warned and unwired on install; the old clone is not deleted.

## Tests
- `npm run generate-catalog:check`
- `npm run format:check`
- `npm run check`
- Focused: sf-brain constitution/routing, sf-skills defaults/gather, sf-welcome skills status/splash
- Full `npm test` after welcome-path updates (prior run failed only on the old afv-library welcome detector)

## Security impact
None. No new org mutations or credential handling.

## Residual risks
Users with the old AFV clone still wired will see a warning until they run `/sf-skills defaults install`. Guide skill names match `forcedotcom/sf-skills` main, not the retired library.