### PR TITLE
fix(sf-skills): give an exact unlink command for retired afv-library

### DIFF
--- a/catalog/index.json
+++ b/catalog/index.json
@@ -906,7 +906,7 @@
     "entry": "extensions/sf-skills/index.ts",
     "hasReadme": true,
     "hasTests": true,
-    "srcLoc": 4815
+    "srcLoc": 4843
   },
   {
     "id": "sf-slack",

--- a/extensions/sf-skills/index.ts
+++ b/extensions/sf-skills/index.ts
@@ -337,7 +337,9 @@ export default function sfSkills(pi: ExtensionAPI) {
     dismissOverlay();
     hudState = EMPTY_STATE;
     if (ctx.mode === "tui") {
-      const warning = formatLegacyDefaultLibraryWarning(detectLegacyDefaultLibrary(ctx.cwd));
+      const warning = formatLegacyDefaultLibraryWarning(detectLegacyDefaultLibrary(ctx.cwd), {
+        sessionStart: true,
+      });
       if (warning) ctx.ui.notify(warning, "warning");
       rebuildAndRender(ctx);
     }

--- a/extensions/sf-skills/lib/defaults.ts
+++ b/extensions/sf-skills/lib/defaults.ts
@@ -179,13 +179,40 @@ export function detectLegacyDefaultLibrary(cwd?: string): LegacyDefaultLibraryDe
 
 export function formatLegacyDefaultLibraryWarning(
   detection: LegacyDefaultLibraryDetection = detectLegacyDefaultLibrary(),
+  options: { sessionStart?: boolean } = {},
 ): string | undefined {
-  if (!detection.present) return undefined;
+  const leftovers = detection.clones.filter((clone) => clone.exists || clone.wired);
+  if (leftovers.length === 0) return undefined;
+  if (options.sessionStart && !detection.wired) return undefined;
+
+  const unlinkCommands = leftovers
+    .filter((clone) => clone.exists || clone.wired)
+    .map((clone) => `/sf-skills defaults unlink ${legacyUnlinkTarget(clone.rootPath)} --delete`)
+    .join(" then ");
+
+  if (detection.wired) {
+    return [
+      "Retired forcedotcom/afv-library is still wired.",
+      "SF Pi now uses forcedotcom/sf-skills.",
+      "Run /sf-skills defaults install to switch, then remove the old clone with",
+      `${unlinkCommands}.`,
+    ].join(" ");
+  }
+
   return [
-    "Retired Salesforce skill library detected (forcedotcom/afv-library).",
-    "SF Pi now installs forcedotcom/sf-skills (platform-apex-generate, not generating-apex).",
-    "Run /sf-skills defaults install to switch. The old clone stays on disk until you unlink --delete.",
+    "A retired forcedotcom/afv-library clone is still on disk but not wired.",
+    "Remove it with",
+    `${unlinkCommands}.`,
   ].join(" ");
+}
+
+function legacyUnlinkTarget(rootPath: string): string {
+  const home = process.env.HOME ?? "";
+  const managed = path.join(home, ".pi", "agent", "sf-skills", LEGACY_LIBRARY_DIR_NAME);
+  if (home && path.normalize(rootPath) === path.normalize(managed)) {
+    return `~/.pi/agent/sf-skills/${LEGACY_LIBRARY_DIR_NAME}`;
+  }
+  return rootPath;
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -263,13 +290,16 @@ export async function installDefaults(options: InstallOptions): Promise<InstallR
   const installed = content.exists
     ? `Already cloned at ${next.rootPath}; ${wiredVerb} in ${wireScope} settings.`
     : `Cloned forcedotcom/sf-skills into ${next.rootPath} and wired it in ${wireScope} settings.`;
-  const legacyNote = legacyRemoved
-    ? " Removed retired forcedotcom/afv-library wiring from this scope."
-    : formatLegacyDefaultLibraryWarning(detectLegacyDefaultLibrary(options.cwd));
+  const leftover = formatLegacyDefaultLibraryWarning(detectLegacyDefaultLibrary(options.cwd));
+  const parts = [
+    installed,
+    legacyRemoved ? "Removed retired forcedotcom/afv-library wiring from this scope." : undefined,
+    leftover,
+  ].filter((part): part is string => Boolean(part));
   return {
     ok: true,
     clone,
-    message: legacyNote ? `${installed} ${legacyNote}` : installed,
+    message: parts.join(" "),
   };
 }
 

--- a/extensions/sf-skills/tests/defaults.test.ts
+++ b/extensions/sf-skills/tests/defaults.test.ts
@@ -271,7 +271,10 @@ describe("legacy afv-library detection", () => {
     const detection = detectLegacyDefaultLibrary();
     expect(detection.present).toBe(true);
     expect(detection.wired).toBe(true);
-    expect(formatLegacyDefaultLibraryWarning(detection)).toMatch(/forcedotcom\/afv-library/);
+    expect(formatLegacyDefaultLibraryWarning(detection)).toMatch(/still wired/);
+    expect(formatLegacyDefaultLibraryWarning(detection)).toMatch(
+      /\/sf-skills defaults unlink ~\/\.pi\/agent\/sf-skills\/afv-library --delete/,
+    );
   });
 
   it("unwires the retired library when installing the new default", async () => {
@@ -296,5 +299,24 @@ describe("legacy afv-library detection", () => {
     );
     expect(settings.skills).toContain("~/.pi/agent/sf-skills/forcedotcom/skills");
     expect(settings.skills).not.toContain("~/.pi/agent/sf-skills/afv-library/skills");
+    expect(result.message).toMatch(
+      /\/sf-skills defaults unlink ~\/\.pi\/agent\/sf-skills\/afv-library --delete/,
+    );
+  });
+
+  it("does not session-warn when the retired clone is only leftover on disk", () => {
+    const home = makeHome();
+    process.env.HOME = home;
+    mkdirSync(path.join(home, ".pi", "agent", "sf-skills", "afv-library", "skills"), {
+      recursive: true,
+    });
+
+    const detection = detectLegacyDefaultLibrary();
+    expect(detection.present).toBe(true);
+    expect(detection.wired).toBe(false);
+    expect(formatLegacyDefaultLibraryWarning(detection, { sessionStart: true })).toBeUndefined();
+    expect(formatLegacyDefaultLibraryWarning(detection)).toMatch(
+      /\/sf-skills defaults unlink ~\/\.pi\/agent\/sf-skills\/afv-library --delete/,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Session start warns only when retired `forcedotcom/afv-library` is still wired.
- The warning now includes the exact `/sf-skills defaults unlink <path> --delete` command.
- An unwired leftover clone no longer tells users to install again.

## Tests
- `extensions/sf-skills/tests/defaults.test.ts`

## Security impact
None.

## Residual risks
Users who already installed `forcedotcom/sf-skills` still need one unlink --delete for the old clone. After this release the session nag stops unless that library remains wired.