### PR TITLE
chore(sf-brain): refresh instruction-surface baseline to 0.271.0

### DIFF
--- a/extensions/sf-brain/instruction-surface-baseline.json
+++ b/extensions/sf-brain/instruction-surface-baseline.json
@@ -1,12 +1,12 @@
 {
   "schema_version": 1,
-  "pi_runtime_version": "0.82.1",
-  "sf_pi_version": "0.250.2",
+  "pi_runtime_version": "0.84.2",
+  "sf_pi_version": "0.271.0",
   "measurement": {
-    "sf_pi_owned_chars": 101553,
-    "sf_pi_tool_definition_chars": 83605,
-    "sf_pi_tool_guidance_chars": 13172,
-    "sf_pi_hidden_context_chars": 4776,
+    "sf_pi_owned_chars": 90749,
+    "sf_pi_tool_definition_chars": 72186,
+    "sf_pi_tool_guidance_chars": 13356,
+    "sf_pi_hidden_context_chars": 5207,
     "bundled_extension_skill_chars": 0
   }
 }


### PR DESCRIPTION
## Why

The bundled Instruction Surface baseline was still `sf-pi 0.250.2` / `Pi 0.82.1`. Comparison requires a matching Pi runtime, so Manager deltas were either incomparable or 20 releases stale.

## What

Replace `extensions/sf-brain/instruction-surface-baseline.json` with a fresh `npm run instruction-surface:report` on **sf-pi 0.271.0** / **Pi 0.84.2**.

| Measurement | 0.250.2 | 0.271.0 | Delta |
|---|---:|---:|---:|
| SF Pi-owned | 101553 | 90749 | -10804 |
| Tool definitions | 83605 | 72186 | -11419 |
| Tool guidance | 13172 | 13356 | +184 |
| Hidden context | 4776 | 5207 | +431 |
| Bundled extension skills | 0 | 0 | 0 |

Re-running the report against the new file compares as **v0.271.0 with all-zero deltas**.

This does not change session context. Slack family collapse is not in this PR.

## Proof

- `npm run instruction-surface:report` comparable to bundled baseline v0.271.0
- `npm run generate-catalog:check`, `format:check`, `check`, and `npm test` (4042 passing)