### PR TITLE
Fix false skill collision warnings for unwired roots

### DIFF
--- a/lib/common/doctor/diagnostics.ts
+++ b/lib/common/doctor/diagnostics.ts
@@ -5,7 +5,7 @@
  * Keep this module side-effect free. Command handlers and startup code use it
  * to decide what to display; repair code lives in fixes.ts.
  */
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from "node:fs";
 import { execFile, execFileSync } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
@@ -58,11 +58,11 @@ export function runDoctorDiagnostics(
   const welcomeMode = typeof welcomeSettings.mode === "string" ? welcomeSettings.mode : undefined;
 
   const skillLocations = discoverSkillLocations({ cwd, home, settings: effectiveSettings });
-  // Root-scan collisions cover all known harness roots (even unwired ones), so
-  // the doctor can proactively warn. In live mode we also union Pi's
-  // authoritative loadSkills collisions so the count can never be LOWER than
-  // what Pi actually reports at startup (and matches the Skill Funnel). The
-  // loader scan is skipped in cached mode to keep first paint off the hot path.
+  // Root-scan collisions cover only Pi's auto-discovered and settings-wired
+  // roots. Unwired harness roots are reported separately as available sources,
+  // not as startup collisions. In live mode we also union Pi's authoritative
+  // loadSkills collisions. The loader scan is skipped in cached mode to keep
+  // first paint off the hot path.
   const skillCollisions =
     runtimeMode === "live"
       ? mergeCollisions(
@@ -280,12 +280,16 @@ export function discoverSkillLocations(options: {
   const roots = buildSkillRootCandidates(options.cwd, options.home, options.settings);
   const locations: SkillLocation[] = [];
   const seenRoots = new Set<string>();
+  const seenSkillFiles = new Set<string>();
   for (const root of roots) {
     const normalizedRoot = path.resolve(root.root);
     if (seenRoots.has(normalizedRoot)) continue;
     seenRoots.add(normalizedRoot);
     if (!isDirectory(normalizedRoot)) continue;
     for (const skill of listImmediateSkills(normalizedRoot)) {
+      const physicalFile = resolvePhysicalPath(skill.file);
+      if (seenSkillFiles.has(physicalFile)) continue;
+      seenSkillFiles.add(physicalFile);
       locations.push({
         name: skill.name,
         file: skill.file,
@@ -395,9 +399,21 @@ function buildSkillRootCandidates(
   home: string,
   settings: Record<string, unknown>,
 ): SkillRootCandidate[] {
+  const skills = Array.isArray(settings.skills) ? settings.skills : [];
+  const wiredRoots = new Set(
+    skills
+      .filter((value): value is string => typeof value === "string")
+      .map((value) => resolvePath(value, home))
+      .filter((value): value is string => !!value)
+      .map((value) => path.resolve(value)),
+  );
   const roots: SkillRootCandidate[] = [
     { root: globalAgentPath("skills"), label: "Pi", kind: "pi" },
     { root: path.join(home, ".agents", "skills"), label: "Agents", kind: "agents" },
+    { root: path.join(cwd, ".pi", "skills"), label: "Project Pi", kind: "project-pi" },
+    { root: path.join(cwd, ".agents", "skills"), label: "Project Agents", kind: "project-agents" },
+  ];
+  const harnessRoots: SkillRootCandidate[] = [
     {
       root: path.join(home, ".claude", "skills"),
       label: "Claude Code",
@@ -416,11 +432,9 @@ function buildSkillRootCandidates(
       kind: "cursor",
       settingsValue: "~/.cursor/skills",
     },
-    { root: path.join(cwd, ".pi", "skills"), label: "Project Pi", kind: "project-pi" },
-    { root: path.join(cwd, ".agents", "skills"), label: "Project Agents", kind: "project-agents" },
   ];
+  roots.push(...harnessRoots.filter((candidate) => wiredRoots.has(path.resolve(candidate.root))));
 
-  const skills = Array.isArray(settings.skills) ? settings.skills : [];
   for (const raw of skills) {
     if (typeof raw !== "string") continue;
     const resolved = resolvePath(raw, home);
@@ -910,6 +924,14 @@ function isDirectory(absolute: string): boolean {
     return statSync(absolute).isDirectory();
   } catch {
     return false;
+  }
+}
+
+function resolvePhysicalPath(file: string): string {
+  try {
+    return realpathSync(file);
+  } catch {
+    return path.resolve(file);
   }
 }
 

--- a/lib/common/doctor/tests/doctor.test.ts
+++ b/lib/common/doctor/tests/doctor.test.ts
@@ -1,6 +1,14 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import { afterEach, describe, expect, it } from "vitest";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { runDoctorDiagnostics } from "../diagnostics.ts";
@@ -58,6 +66,36 @@ describe("runDoctorDiagnostics", () => {
       expect(report.skillCollisions[0]!.preferred.rootKind).toBe("claude");
       expect(report.skillCollisions[0]!.duplicates[0]!.rootKind).toBe("pi");
       expect(report.issues.some((issue) => issue.id === "skill-collisions")).toBe(true);
+    },
+    DOCTOR_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "ignores unwired harness roots and duplicate symlinks to one physical skill",
+    () => {
+      const home = makeHome();
+      const cwd = mkdtempSync(path.join(tmpdir(), "sf-pi-doctor-cwd-"));
+      tempDirs.push(cwd);
+      writeSettings(home, {});
+      const agentsRoot = path.join(home, ".agents", "skills");
+      const sharedSkill = path.join(agentsRoot, "shared-skill");
+      writeSkill(agentsRoot, "shared-skill");
+      const piRoot = path.join(home, ".pi", "agent", "skills");
+      const claudeRoot = path.join(home, ".claude", "skills");
+      for (const root of [piRoot, claudeRoot]) {
+        mkdirSync(root, { recursive: true });
+        symlinkSync(sharedSkill, path.join(root, "shared-skill"));
+      }
+      writeSkill(piRoot, "unwired-copy");
+      writeSkill(claudeRoot, "unwired-copy");
+
+      const report = runDoctorDiagnostics({ cwd, home, runtime: "cached" });
+
+      expect(report.skillCollisions).toEqual([]);
+      expect(report.issues.some((issue) => issue.id === "skill-collisions")).toBe(false);
+      expect(report.availableSkillRoots.map((root) => root.settingsPath)).toContain(
+        "~/.claude/skills",
+      );
     },
     DOCTOR_TEST_TIMEOUT_MS,
   );


### PR DESCRIPTION
## Summary

Limit doctor collision scans to Pi auto-discovered roots and roots explicitly wired through `settings.skills[]`. Keep unwired Claude, Codex, and Cursor roots in the available-source report without treating their skills as startup collisions. Resolve skill paths to their physical files so symlink aliases to the same `SKILL.md` do not count as separate copies.

## Behavior proof

Added a regression test covering an unwired harness copy and multiple symlinks to one physical skill. The test failed before the implementation and passes after it.

## Validation

- `npm run generate-catalog:check`
- `npm run format:check`
- `npm run check`
- `npm test` with 571 test files passed, 1 skipped; 4126 tests passed, 39 skipped
- Live and cached doctor probes both report zero collisions while retaining the three available external roots in the reproduced setup