### PR TITLE
chore(deps-dev): upgrade vitest and coverage-v8 to 5.0.0

### DIFF
--- a/extensions/sf-agentscript/tests/__snapshots__/diagnostic-parity.test.ts.snap
+++ b/extensions/sf-agentscript/tests/__snapshots__/diagnostic-parity.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`local hardening diagnostic parity > '@inputs reference outside action with…' 1`] = `
+exports[`local hardening diagnostic parity > @inputs reference outside action with-b… 1`] = `
 {
   "decision": "retain-local",
   "execution_context": "@inputs reference in deterministic post-action set",
@@ -63,7 +63,7 @@ exports[`local hardening diagnostic parity > '@inputs reference outside action w
 }
 `;
 
-exports[`local hardening diagnostic parity > '@outputs reference outside post-actio…' 1`] = `
+exports[`local hardening diagnostic parity > @outputs reference outside post-action … 1`] = `
 {
   "decision": "retain-local",
   "execution_context": "@outputs reference in deterministic action with-binding",
@@ -91,7 +91,7 @@ exports[`local hardening diagnostic parity > '@outputs reference outside post-ac
 }
 `;
 
-exports[`local hardening diagnostic parity > 'Apex target with method suffix' 1`] = `
+exports[`local hardening diagnostic parity > Apex target with method suffix 1`] = `
 {
   "decision": "retain-local",
   "execution_context": "Apex action target declaration",
@@ -122,7 +122,7 @@ exports[`local hardening diagnostic parity > 'Apex target with method suffix' 1`
 }
 `;
 
-exports[`local hardening diagnostic parity > 'bare numeric action inputs and outputs' 1`] = `
+exports[`local hardening diagnostic parity > bare numeric action inputs and outputs 1`] = `
 {
   "decision": "historical-no-local-projection",
   "execution_context": "planner-selected numeric action binding",
@@ -150,7 +150,7 @@ exports[`local hardening diagnostic parity > 'bare numeric action inputs and out
 }
 `;
 
-exports[`local hardening diagnostic parity > 'object action I/O without contract hi…' 1`] = `
+exports[`local hardening diagnostic parity > object action I/O without contract hints 1`] = `
 {
   "decision": "completed-upstream-handoff",
   "execution_context": "planner-selected object action binding",
@@ -212,7 +212,7 @@ exports[`local hardening diagnostic parity > 'object action I/O without contract
 }
 `;
 
-exports[`local hardening diagnostic parity > 'procedural statements inside literal …' 1`] = `
+exports[`local hardening diagnostic parity > procedural statements inside literal in… 1`] = `
 {
   "decision": "completed-upstream-handoff",
   "execution_context": "procedural-looking content in literal instructions",
@@ -290,7 +290,7 @@ exports[`local hardening diagnostic parity > 'procedural statements inside liter
 }
 `;
 
-exports[`local hardening diagnostic parity > 'target reference that looks like a Sa…' 1`] = `
+exports[`local hardening diagnostic parity > target reference that looks like a Sale… 1`] = `
 {
   "decision": "retain-local",
   "execution_context": "Flow action target declaration",

--- a/extensions/sf-agentscript/tests/__snapshots__/quality-upstream-parity.test.ts.snap
+++ b/extensions/sf-agentscript/tests/__snapshots__/quality-upstream-parity.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`quality upstream strict parity > 'conditional transition cycle' 1`] = `
+exports[`quality upstream strict parity > conditional transition cycle 1`] = `
 {
   "decision": "retain-local",
   "execution_context": "component graph with conditional deterministic transitions",
@@ -59,7 +59,7 @@ exports[`quality upstream strict parity > 'conditional transition cycle' 1`] = `
 }
 `;
 
-exports[`quality upstream strict parity > 'cyclomatic complexity' 1`] = `
+exports[`quality upstream strict parity > cyclomatic complexity 1`] = `
 {
   "decision": "retain-local",
   "execution_context": "procedure with if and short-circuit expressions",
@@ -119,7 +119,7 @@ exports[`quality upstream strict parity > 'cyclomatic complexity' 1`] = `
 }
 `;
 
-exports[`quality upstream strict parity > 'deep deterministic action chain' 1`] = `
+exports[`quality upstream strict parity > deep deterministic action chain 1`] = `
 {
   "decision": "retain-local",
   "execution_context": "second nested deterministic follow-up",
@@ -171,7 +171,7 @@ exports[`quality upstream strict parity > 'deep deterministic action chain' 1`] 
 }
 `;
 
-exports[`quality upstream strict parity > 'delegation cycle and unreachable suba…' 1`] = `
+exports[`quality upstream strict parity > delegation cycle and unreachable subage… 1`] = `
 {
   "decision": "retain-local",
   "execution_context": "returning subagent graph plus orphan declaration",
@@ -269,7 +269,7 @@ exports[`quality upstream strict parity > 'delegation cycle and unreachable suba
 }
 `;
 
-exports[`quality upstream strict parity > 'deterministic input type mismatch' 1`] = `
+exports[`quality upstream strict parity > deterministic input type mismatch 1`] = `
 {
   "decision": "retain-local",
   "execution_context": "deterministic run with known literal input type",
@@ -321,7 +321,7 @@ exports[`quality upstream strict parity > 'deterministic input type mismatch' 1`
 }
 `;
 
-exports[`quality upstream strict parity > 'deterministic missing input' 1`] = `
+exports[`quality upstream strict parity > deterministic missing input 1`] = `
 {
   "decision": "retain-local",
   "execution_context": "deterministic run in reasoning.instructions",
@@ -373,7 +373,7 @@ exports[`quality upstream strict parity > 'deterministic missing input' 1`] = `
 }
 `;
 
-exports[`quality upstream strict parity > 'deterministic output type mismatch' 1`] = `
+exports[`quality upstream strict parity > deterministic output type mismatch 1`] = `
 {
   "decision": "retain-local",
   "execution_context": "deterministic run output assigned to mutable variable",
@@ -425,7 +425,7 @@ exports[`quality upstream strict parity > 'deterministic output type mismatch' 1
 }
 `;
 
-exports[`quality upstream strict parity > 'deterministic slot filling' 1`] = `
+exports[`quality upstream strict parity > deterministic slot filling 1`] = `
 {
   "decision": "retain-local",
   "execution_context": "deterministic run with ellipsis input",
@@ -477,7 +477,7 @@ exports[`quality upstream strict parity > 'deterministic slot filling' 1`] = `
 }
 `;
 
-exports[`quality upstream strict parity > 'deterministic unknown input' 1`] = `
+exports[`quality upstream strict parity > deterministic unknown input 1`] = `
 {
   "decision": "retain-local",
   "execution_context": "deterministic run with misspelled with-binding",
@@ -567,7 +567,7 @@ exports[`quality upstream strict parity > 'deterministic unknown input' 1`] = `
 }
 `;
 
-exports[`quality upstream strict parity > 'instruction template syntax' 1`] = `
+exports[`quality upstream strict parity > instruction template syntax 1`] = `
 {
   "decision": "reuse-upstream",
   "execution_context": "official instruction interpolation diagnostic projected into quality",
@@ -666,7 +666,7 @@ exports[`quality upstream strict parity > 'instruction template syntax' 1`] = `
 }
 `;
 
-exports[`quality upstream strict parity > 'list element and index types' 1`] = `
+exports[`quality upstream strict parity > list element and index types 1`] = `
 {
   "decision": "retain-local",
   "execution_context": "typed list literal and statically nonnumeric subscript",
@@ -755,7 +755,7 @@ exports[`quality upstream strict parity > 'list element and index types' 1`] = `
 }
 `;
 
-exports[`quality upstream strict parity > 'planner action input type mismatch' 1`] = `
+exports[`quality upstream strict parity > planner action input type mismatch 1`] = `
 {
   "execution_context": "planner-selected reasoning.actions binding",
   "local_diagnostics": [],
@@ -785,7 +785,7 @@ exports[`quality upstream strict parity > 'planner action input type mismatch' 1
 }
 `;
 
-exports[`quality upstream strict parity > 'planner action missing input' 1`] = `
+exports[`quality upstream strict parity > planner action missing input 1`] = `
 {
   "execution_context": "planner-selected reasoning.actions binding",
   "local_diagnostics": [],
@@ -812,7 +812,7 @@ exports[`quality upstream strict parity > 'planner action missing input' 1`] = `
 }
 `;
 
-exports[`quality upstream strict parity > 'planner action unknown input' 1`] = `
+exports[`quality upstream strict parity > planner action unknown input 1`] = `
 {
   "execution_context": "planner-selected reasoning.actions binding",
   "local_diagnostics": [],
@@ -858,7 +858,7 @@ exports[`quality upstream strict parity > 'planner action unknown input' 1`] = `
 }
 `;
 
-exports[`quality upstream strict parity > 'prompt and action before transition' 1`] = `
+exports[`quality upstream strict parity > prompt and action before transition 1`] = `
 {
   "decision": "retain-local",
   "execution_context": "procedure statements before guaranteed transition",
@@ -947,7 +947,7 @@ exports[`quality upstream strict parity > 'prompt and action before transition' 
 }
 `;
 
-exports[`quality upstream strict parity > 'prompt template output flags' 1`] = `
+exports[`quality upstream strict parity > prompt template output flags 1`] = `
 {
   "decision": "retain-local",
   "execution_context": "prompt-response action output declaration",
@@ -999,7 +999,7 @@ exports[`quality upstream strict parity > 'prompt template output flags' 1`] = `
 }
 `;
 
-exports[`quality upstream strict parity > 'slot-filled variable description' 1`] = `
+exports[`quality upstream strict parity > slot-filled variable description 1`] = `
 {
   "decision": "retain-local",
   "execution_context": "planner-selected setVariables binding",
@@ -1102,7 +1102,7 @@ exports[`quality upstream strict parity > 'slot-filled variable description' 1`]
 }
 `;
 
-exports[`quality upstream strict parity > 'unconditional transition cycle' 1`] = `
+exports[`quality upstream strict parity > unconditional transition cycle 1`] = `
 {
   "decision": "retain-local",
   "execution_context": "component graph with unconditional deterministic transitions",
@@ -1163,7 +1163,7 @@ exports[`quality upstream strict parity > 'unconditional transition cycle' 1`] =
 }
 `;
 
-exports[`quality upstream strict parity > 'unused action' 1`] = `
+exports[`quality upstream strict parity > unused action 1`] = `
 {
   "decision": "retain-local",
   "execution_context": "scoped action declaration without invocation",
@@ -1215,7 +1215,7 @@ exports[`quality upstream strict parity > 'unused action' 1`] = `
 }
 `;
 
-exports[`quality upstream strict parity > 'variable description max length' 1`] = `
+exports[`quality upstream strict parity > variable description max length 1`] = `
 {
   "decision": "retain-local",
   "execution_context": "variable declaration with a description over the publish limit",

--- a/extensions/sf-skills/tests/pi-resource-parity.test.ts
+++ b/extensions/sf-skills/tests/pi-resource-parity.test.ts
@@ -342,7 +342,7 @@ afterAll(() => {
   );
 });
 
-describe.sequential("E4 Pi resource resolution parity", () => {
+describe("E4 Pi resource resolution parity", { concurrent: false }, () => {
   it("matches global top-level loading inherited by a project", async () => {
     const fixture = makeFixture("sf-skills-e4-global-");
     const root = path.join(fixture.home, "external", "skills");

--- a/extensions/sf-tldraw/tests/data-model-gallery-matrix.live.test.ts
+++ b/extensions/sf-tldraw/tests/data-model-gallery-matrix.live.test.ts
@@ -105,7 +105,7 @@ let qualification: { status: "pending" | "passed" | "failed"; message?: string }
   status: liveEnabled ? "pending" : "passed",
 };
 
-describe.sequential("sf-tldraw Data Model Gallery matrix", () => {
+describe("sf-tldraw Data Model Gallery matrix", { concurrent: false }, () => {
   beforeAll(async () => {
     if (!liveEnabled) return;
     client = new TldrawRuntimeClient({ timeoutMs: 120_000 });

--- a/extensions/sf-tldraw/tests/sequence-matrix.live.test.ts
+++ b/extensions/sf-tldraw/tests/sequence-matrix.live.test.ts
@@ -57,7 +57,7 @@ let documentId: string | undefined;
 let preflight: Record<string, unknown> = { status: liveEnabled ? "pending" : "disabled" };
 let preflightError: Error | undefined;
 
-describe.sequential("sf-tldraw sequence hardening matrix", () => {
+describe("sf-tldraw sequence hardening matrix", { concurrent: false }, () => {
   beforeAll(async () => {
     if (!liveEnabled) return;
     client = new TldrawRuntimeClient();

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@eslint/js": "^10.0.1",
         "@sf-agentscript/agentfabric-dialect": "1.2.36",
         "@types/node": "^26.4.1",
-        "@vitest/coverage-v8": "^4.1.11",
+        "@vitest/coverage-v8": "^5.0.0",
         "eslint": "^10.9.1",
         "globals": "^17.12.0",
         "husky": "^9.1.7",
@@ -47,7 +47,7 @@
         "typescript-eslint": "^8.69.0",
         "vite": "7.3.6",
         "vitepress": "^1.6.4",
-        "vitest": "^4.1.11"
+        "vitest": "^5.0.0"
       },
       "engines": {
         "node": ">=22.19"
@@ -6156,13 +6156,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@standard-schema/spec": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
@@ -6608,29 +6601,27 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.11.tgz",
-      "integrity": "sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-5.0.0.tgz",
+      "integrity": "sha512-toMg6PZGCIa/lQNCDoASrfb1ly4hsUKXFtFYC9kD4t78o5Y6LyNJU7AENt8eHPr3quYdxaxK7hj2mnbFfUk9NA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.11",
-        "ast-v8-to-istanbul": "^1.0.0",
-        "istanbul-lib-coverage": "^3.2.2",
-        "istanbul-lib-report": "^3.0.1",
-        "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.2",
-        "obug": "^2.1.1",
-        "std-env": "^4.0.0-rc.1",
-        "tinyrainbow": "^3.1.0"
+        "@vitest/istanbul-lib-coverage": "^1.0.0",
+        "@vitest/istanbul-lib-report": "^1.0.0",
+        "ast-v8-to-istanbul": "^1.0.5",
+        "magicast": "^0.5.4",
+        "obug": "^2.1.4",
+        "std-env": "^4.2.0",
+        "tinyrainbow": "^3.1.1"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.11",
-        "vitest": "4.1.11"
+        "@vitest/browser": "5.0.0",
+        "vitest": "5.0.0"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -6638,34 +6629,40 @@
         }
       }
     },
-    "node_modules/@vitest/expect": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
-      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+    "node_modules/@vitest/istanbul-lib-coverage": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@vitest/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.1.tgz",
+      "integrity": "sha512-k3DJZ8LhMBK9NS4SclF1ASD3OgXEWDorbIcPTRDK0/Zae6fRvu+fJRxtFdLfHsa9Y24beCdPnoNZ4LviTNstfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@vitest/istanbul-lib-report": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@vitest/istanbul-lib-report/-/istanbul-lib-report-1.0.1.tgz",
+      "integrity": "sha512-1EOLRfsTMnyAr3+kEAsP4o9dhaDlGPpD7H5iLBBeq//YpNB1VIahkPhB+eRp9N2Dkfw8oySROjE3yf9XDeaIkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.1.0",
-        "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.11",
-        "@vitest/utils": "4.1.11",
-        "chai": "^6.2.2",
-        "tinyrainbow": "^3.1.0"
+        "@vitest/istanbul-lib-coverage": "1.0.1"
       },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
-      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-5.0.0.tgz",
+      "integrity": "sha512-66PGTMIiVJP3t4a5yxU9qPtf7MdTBs8jmToMvy+HVflB3Yy13WJZTtPePdvU+wjRV02SKK5doLbSA6o9pwOmiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.11",
+        "@jridgewell/trace-mapping": "0.3.31",
+        "@vitest/spy": "5.0.0",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21"
+        "magic-string": "^1.2.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -6683,70 +6680,22 @@
         }
       }
     },
-    "node_modules/@vitest/pretty-format": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
-      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+    "node_modules/@vitest/mocker/node_modules/magic-string": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+      "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/runner": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
-      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/utils": "4.1.11",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/snapshot": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
-      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.11",
-        "@vitest/utils": "4.1.11",
-        "magic-string": "^0.30.21",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
-      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-5.0.0.tgz",
+      "integrity": "sha512-uy+luWBAPw9XfthoHi5AkfHUnuPYEESjl0p/r+meoBnU8bxg5GDQ3Ey8MjcJ6sqahkL4PFyrvfMJJBw7LbU06g==",
       "dev": true,
       "license": "MIT",
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/utils": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
-      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.11",
-        "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.1.0"
-      },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
@@ -7190,9 +7139,9 @@
       }
     },
     "node_modules/ast-v8-to-istanbul": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
-      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.6.tgz",
+      "integrity": "sha512-fvpl29helSO2w/z7utIbrkNXILdrLwDwAMH2I/zPKlGf5244+gf+B4cyS1sANcrPY2h+hWCGSgC8N61s/+AF9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8072,9 +8021,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
       "dev": true,
       "license": "MIT"
     },
@@ -8442,9 +8391,9 @@
       }
     },
     "node_modules/expect-type": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
-      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -9888,14 +9837,14 @@
       }
     },
     "node_modules/magicast": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
-      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "source-map-js": "^1.2.1"
       }
     },
@@ -10373,15 +10322,18 @@
       }
     },
     "node_modules/obug": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
@@ -10646,13 +10598,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
@@ -11534,9 +11479,9 @@
       }
     },
     "node_modules/std-env": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
     },
@@ -11705,11 +11650,14 @@
       "license": "MIT"
     },
     "node_modules/tinybench": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
-      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-6.1.4.tgz",
+      "integrity": "sha512-9APumHG7r4yOk4X4WlkmE71aZcv1gvin1czO3OQ1U9iJcFA5Ja/ygyb0vPOVHTthFozUYs8CLoLUlM8grb2lTQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/tinyexec": {
       "version": "1.3.0",
@@ -11739,9 +11687,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12306,38 +12254,31 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
-      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-5.0.0.tgz",
+      "integrity": "sha512-gpsMNoRhMjMktVxPtstOH4/PJuPyovVaMDr4oDilXaGH1EcqM2OE96SoHT2VIQ6fTGtTjqmHDrEu2X9RQiXf8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.11",
-        "@vitest/mocker": "4.1.11",
-        "@vitest/pretty-format": "4.1.11",
-        "@vitest/runner": "4.1.11",
-        "@vitest/snapshot": "4.1.11",
-        "@vitest/spy": "4.1.11",
-        "@vitest/utils": "4.1.11",
-        "es-module-lexer": "^2.0.0",
-        "expect-type": "^1.3.0",
-        "magic-string": "^0.30.21",
-        "obug": "^2.1.1",
-        "pathe": "^2.0.3",
-        "picomatch": "^4.0.3",
-        "std-env": "^4.0.0-rc.1",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^1.0.2",
-        "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.1.0",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/mocker": "5.0.0",
+        "chai": "^6.2.2",
+        "es-module-lexer": "^2.3.2",
+        "expect-type": "^1.4.0",
+        "magic-string": "^1.2.3",
+        "obug": "^2.1.4",
+        "picomatch": "^4.0.7",
+        "std-env": "^4.2.0",
+        "tinybench": "6.1.4",
+        "tinyexec": "1.3.0",
+        "tinyglobby": "^0.2.17",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+        "node": "^22.12.0 || ^24.0.0 || >=26.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -12345,16 +12286,16 @@
       "peerDependencies": {
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
-        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.11",
-        "@vitest/browser-preview": "4.1.11",
-        "@vitest/browser-webdriverio": "4.1.11",
-        "@vitest/coverage-istanbul": "4.1.11",
-        "@vitest/coverage-v8": "4.1.11",
-        "@vitest/ui": "4.1.11",
+        "@types/node": "^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "5.0.0",
+        "@vitest/browser-preview": "5.0.0",
+        "@vitest/browser-webdriverio": "^5.0.0-beta.5 || >=5.0.0",
+        "@vitest/coverage-istanbul": "5.0.0",
+        "@vitest/coverage-v8": "5.0.0",
+        "@vitest/ui": "5.0.0",
         "happy-dom": "*",
         "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "vite": "^6.4.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
@@ -12395,79 +12336,31 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/vite": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
-      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+      "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/vitest/node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
+        "picomatch": "^4.0.4"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": ">=12.0.0"
       },
       "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
-        "jiti": ">=1.21.0",
-        "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
+        "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
     "node_modules/vscode-jsonrpc": {

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "@eslint/js": "^10.0.1",
     "@sf-agentscript/agentfabric-dialect": "1.2.36",
     "@types/node": "^26.4.1",
-    "@vitest/coverage-v8": "^4.1.11",
+    "@vitest/coverage-v8": "^5.0.0",
     "eslint": "^10.9.1",
     "globals": "^17.12.0",
     "husky": "^9.1.7",
@@ -140,7 +140,7 @@
     "typescript-eslint": "^8.69.0",
     "vite": "7.3.6",
     "vitepress": "^1.6.4",
-    "vitest": "^4.1.11"
+    "vitest": "^5.0.0"
   },
   "dependencies": {
     "@dagrejs/dagre": "3.1.1",

--- a/scripts/tests/manager-first-commands.test.ts
+++ b/scripts/tests/manager-first-commands.test.ts
@@ -28,7 +28,7 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-describe.sequential("Manager-first no-args command contract", () => {
+describe("Manager-first no-args command contract", { concurrent: false }, () => {
   for (const extension of commandExtensions) {
     it(
       extension.id,

--- a/scripts/tests/runtime-surface-attestation.test.ts
+++ b/scripts/tests/runtime-surface-attestation.test.ts
@@ -212,7 +212,7 @@ describe("runtime surface isolation", () => {
   });
 });
 
-describe.sequential("real extension factories match manifest runtime surfaces", () => {
+describe("real extension factories match manifest runtime surfaces", { concurrent: false }, () => {
   for (const manifest of manifests) {
     it(
       manifest.id,


### PR DESCRIPTION
## What this PR does

Upgrade `vitest` and `@vitest/coverage-v8` together from 4.1.11 to 5.0.0, replacing the Dependabot majors that could not land separately.

## Why

Dependabot split the major into #672 (`@vitest/coverage-v8` only, false-green) and #673 (`vitest` only, Validate failed). Vitest 5 removed `describe.sequential`, so both packages have to move in one PR with the call-site fix.

Replaces #672 and #673.

## How

- Bump `vitest` and `@vitest/coverage-v8` to `^5.0.0` in the same lockfile
- Replace `describe.sequential(...)` with `describe(..., { concurrent: false })` in five suites that share module, filesystem, or live-canvas state
- Refresh `test.each` snapshot keys after Vitest 5 stopped quoting `$name` interpolations (payloads unchanged)

Kept the existing Vite 7 override. Did not change `isolate` even though Vitest 5 prints a performance hint.

## Checklist

- [x] I ran focused checks locally (listed below)
- [ ] I updated the affected extension's `README.md` (if behavior changed)
- [x] I added or updated tests
- [ ] I regenerated the catalog (`npm run generate-catalog`) if I touched `manifest.json`
- [x] This PR is non-breaking for product runtime; it is a test-runner major with the required call-site and snapshot updates

## Security and public-surface checklist

- [x] I considered whether this adds or changes a high-value durable mutation exposed through an LLM-callable tool
- [x] Public docs, examples, tests, comments, and diagnostics do not include secrets, customer names, real org/workspace identifiers, private hostnames, internal links, or copied private-source wording

## Validation performed

- `npm run check` — pass
- `npm test` — 4125 passed, 39 skipped
- `npm run test:coverage` — statements 64.03%, branches 52.8%, functions 69.97%, lines 66.18% (above floors 60/49/66/62)
- `npm run generate-catalog:check` — pass
- `npm run format:check` — pass

## Notes for reviewers

- Node `>=22.19` and Vite 7.3.6 already satisfy Vitest 5 (`Node >=22.12`, `Vite >=6.4`).
- `clearMocks` now defaults to `true`; this suite passed without setting it back to `false`.
- Follow-up, not in this PR: `vitest doctor` / `isolate: false` if we want the reported ~4s file-isolation saving.
