### PR TITLE
fix(security): close open CodeQL alerts on main

### DIFF
--- a/catalog/index.json
+++ b/catalog/index.json
@@ -497,7 +497,7 @@
     "entry": "extensions/sf-docs/index.ts",
     "hasReadme": true,
     "hasTests": true,
-    "srcLoc": 4443
+    "srcLoc": 4444
   },
   {
     "id": "sf-feedback",
@@ -912,7 +912,7 @@
     "entry": "extensions/sf-skills/index.ts",
     "hasReadme": true,
     "hasTests": true,
-    "srcLoc": 6012
+    "srcLoc": 6018
   },
   {
     "id": "sf-slack",

--- a/extensions/sf-docs/lib/developer-reference.ts
+++ b/extensions/sf-docs/lib/developer-reference.ts
@@ -82,7 +82,8 @@ export function isAtlasDeveloperReferenceLocator(value: string): boolean {
     return comparable.includes("/docs/atlas") || comparable.includes("atlas.en-us");
   } catch {
     return (
-      /\batlas\.en-us\b/iu.test(value) || /developer\.salesforce\.com\/docs\/atlas/iu.test(value)
+      /\batlas\.en-us\b/iu.test(value) ||
+      /^(?:https?:\/\/)?developer\.salesforce\.com\/docs\/atlas/iu.test(value)
     );
   }
 }

--- a/extensions/sf-docs/tests/developer-reference.test.ts
+++ b/extensions/sf-docs/tests/developer-reference.test.ts
@@ -91,4 +91,18 @@ describe("Developer reference routing", () => {
       fallbackCollection: "developer",
     });
   });
+
+  it("rejects host-confused Atlas lookalikes and still accepts scheme-less Atlas paths", () => {
+    expect(
+      isAtlasDeveloperReferenceLocator(
+        "https://evil.example/developer.salesforce.com/docs/atlas.en-us.apexref",
+      ),
+    ).toBe(false);
+    expect(
+      isAtlasDeveloperReferenceLocator(
+        "developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex.htm",
+      ),
+    ).toBe(true);
+    expect(isAtlasDeveloperReferenceLocator("notes about atlas.en-us in a query")).toBe(true);
+  });
 });

--- a/extensions/sf-skills/lib/invocation/effective-tree.ts
+++ b/extensions/sf-skills/lib/invocation/effective-tree.ts
@@ -97,9 +97,15 @@ export function syncEffectiveSkills(
       authorDisabled,
       policy,
     });
-    const currentRaw = existsSync(effectiveFile) ? readFileSync(effectiveFile, "utf8") : cloneRaw;
-    const next = applyInvocationMode(currentRaw, desiredMode);
-    if (next !== currentRaw || !existsSync(effectiveFile)) {
+    let currentRaw: string | undefined;
+    try {
+      currentRaw = readFileSync(effectiveFile, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+    const baseRaw = currentRaw ?? cloneRaw;
+    const next = applyInvocationMode(baseRaw, desiredMode);
+    if (currentRaw === undefined || next !== currentRaw) {
       mkdirSync(path.dirname(effectiveFile), { recursive: true });
       writeFileSync(effectiveFile, next, "utf8");
       stamped += 1;

--- a/lib/common/display/settings.ts
+++ b/lib/common/display/settings.ts
@@ -11,9 +11,9 @@
  * Project settings override global settings. Missing or invalid values fall
  * back to the balanced profile so existing behavior stays stable.
  */
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import path from "node:path";
+import { existsSync, readFileSync } from "node:fs";
 import { globalSettingsPath, projectSettingsPath } from "../pi-paths.ts";
+import { writeJsonFile } from "../sf-pi-settings.ts";
 import {
   DEFAULT_SF_PI_DISPLAY_SETTINGS,
   normalizeSfPiDisplaySettings,
@@ -118,8 +118,7 @@ export function writeScopedSfPiDisplaySettings(
   const normalized = normalizeSfPiDisplaySettings(settings);
   const nextRoot = writeDisplaySettingsToRoot(root, normalized);
 
-  mkdirSync(path.dirname(filePath), { recursive: true });
-  writeFileSync(filePath, `${JSON.stringify(nextRoot, null, 2)}\n`, "utf8");
+  writeJsonFile(filePath, nextRoot);
 
   return {
     scope,

--- a/lib/common/sf-pi-settings.ts
+++ b/lib/common/sf-pi-settings.ts
@@ -47,5 +47,8 @@ export function readJsonFile(filePath: string): Record<string, unknown> {
 /** Write a JSON object to disk, creating parent directories as needed. */
 export function writeJsonFile(filePath: string, data: Record<string, unknown>): void {
   mkdirSync(path.dirname(filePath), { recursive: true });
+  // Writes Pi settings.json (globalAgentDir or <cwd>/.pi), not an OS temp file.
+  // CodeQL taints getAgentDir() because tests override the agent dir under os.tmpdir().
+  // codeql[js/insecure-temporary-file]
   writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
 }

--- a/lib/common/skill-sources/skill-sources.ts
+++ b/lib/common/skill-sources/skill-sources.ts
@@ -20,10 +20,11 @@
  * Scope: this module never shells out to `pi install` and never runs
  * network. It is a pure settings-file writer + disk scanner.
  */
-import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { globalSettingsPath, projectSettingsPath } from "../pi-paths.ts";
+import { writeJsonFile } from "../sf-pi-settings.ts";
 
 /** Where a candidate writes when the user opts it in. */
 export type SkillSourceScope = "global" | "project";
@@ -282,8 +283,7 @@ export function updateSkillSources(args: {
   }
 
   const nextRoot = { ...root, skills: retained };
-  mkdirSync(path.dirname(settingsPath), { recursive: true });
-  writeFileSync(settingsPath, `${JSON.stringify(nextRoot, null, 2)}\n`, "utf8");
+  writeJsonFile(settingsPath, nextRoot);
   return { settingsPath, skills: retained };
 }
 


### PR DESCRIPTION
## What this PR does

Close the five open CodeQL alerts on `main` (#112–#116).

## Why

Code scanning on `main` currently shows five High alerts. Two are real, cheap defects. Three are false positives: Pi `settings.json` writes, not OS temp files.

## How

- **#113** (`js/regex/missing-regexp-anchor`): anchor the fallback Atlas host regex so `evil.example/developer.salesforce.com/docs/atlas` cannot match after `new URL()` fails
- **#112** (`js/file-system-race`): read the effective `SKILL.md` and treat `ENOENT` as missing, instead of `existsSync` then `readFileSync`
- **#114–#116** (`js/insecure-temporary-file`): route display and skill-source settings writes through `writeJsonFile`, and suppress the sink. Those paths are `globalAgentDir/settings.json` or `<cwd>/.pi/settings.json`. CodeQL taints `getAgentDir()` because tests override the agent dir under `os.tmpdir()`.

## Checklist

- [x] I ran focused checks locally (listed below)
- [ ] I updated the affected extension's `README.md` (if behavior changed)
- [x] I added or updated tests
- [x] I regenerated the catalog (`npm run generate-catalog`) if I touched `manifest.json`
- [x] This PR is non-breaking, or I called out the breaking change explicitly above

## Security and public-surface checklist

- [x] I considered whether this adds or changes a high-value durable mutation exposed through an LLM-callable tool
- [x] Public docs, examples, tests, comments, and diagnostics do not include secrets, customer names, real org/workspace identifiers, private hostnames, internal links, or copied private-source wording

## Validation performed

- `npm run check` — pass
- focused vitest for display settings, skill-sources, developer-reference, effective-tree — pass
- `npm test` — 4126 passed, 39 skipped

## Notes for reviewers

Alerts should auto-close after CodeQL runs on this PR / merge to `main`.
